### PR TITLE
Fix flaky build: add TPtrIR dependency to TritonShared plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (TRITON_SHARED_BUILD_CPU_BACKEND)
     get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
     get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 
-    add_triton_plugin(TritonShared ${CMAKE_CURRENT_SOURCE_DIR}/triton_shared.cc LINK_LIBS TritonSharedAnalysis TritonTilingExtIR ${conversion_libs} ${extension_libs} MLIRSparseTensorTransforms MLIRControlFlowTransforms MLIRTensorInferTypeOpInterfaceImpl)
+    add_triton_plugin(TritonShared ${CMAKE_CURRENT_SOURCE_DIR}/triton_shared.cc LINK_LIBS TritonSharedAnalysis TritonTilingExtIR TPtrIR ${conversion_libs} ${extension_libs} MLIRSparseTensorTransforms MLIRControlFlowTransforms MLIRTensorInferTypeOpInterfaceImpl)
     target_link_libraries(TritonShared PRIVATE Python3::Module pybind11::headers)
 endif()
 


### PR DESCRIPTION
## Summary
- Adds `TPtrIR` to `LINK_LIBS` of the `TritonShared` plugin target in the root `CMakeLists.txt`

The `TritonShared` pybind plugin includes `TPtrDialect.h` (via `triton_shared.cc`), which requires the tablegen-generated `TPtrDialect.h.inc`. Without an explicit dependency on `TPtrIR` (which depends on `TPtrTableGen`), parallel builds (`-j8`) can schedule the `.cc.o` compilation before the `.h.inc` file is generated, causing:

```
fatal error: 'triton-shared/Dialect/TPtr/IR/TPtrDialect.h.inc' file not found
```

Fixes #19

## Test plan
- [x] Verified the fix resolves the flaky build in downstream CI (amd/Triton-XDNA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)