### PR TITLE
Update PtrAnalysis to handle bounds clamping

### DIFF
--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -147,6 +147,17 @@ class PtrAnalysis {
       scf::ForOp forOp, size_t ptrArgIndex, const PtrState &state,
       llvm::function_ref<Value(scf::ForOp op, size_t)> getReplacementVal);
 
+  // Shared implementation for visitOperandMinSI and visitOperandMaxSI.
+  // Main assumptions:
+  //  Current PtrState should be empty
+  // Expected result:
+  //  If lhsState is scalar: state = rhsState
+  //  If rhsState is scalar: state = lhsState
+  //  If lhsState is structured and rhsState is not: state = rhsState
+  //  Otherwise: state = lhsState
+  LogicalResult visitOperandMinMaxSI(Value lhs, Value rhs, PtrState &state,
+                                     const Location loc, OpBuilder &builder);
+
   DenseSet<Value> maybeStructuredArgs;
   const bool enableMakeGatherScatterTensorPtr;
   // If false, PtrAnalysis will analysis structured ptr while only identify
@@ -235,6 +246,16 @@ public:
 
   LogicalResult visitOperandRem(arith::RemSIOp mulOp, PtrState &state,
                                 const Location loc, OpBuilder &builder);
+
+  // Operand is the result of arith.minsi. Process both arguments.
+  // Current PtrState should be empty. See visitOperandMinMaxSI for semantics.
+  LogicalResult visitOperandMinSI(arith::MinSIOp minOp, PtrState &state,
+                                  const Location loc, OpBuilder &builder);
+
+  // Operand is the result of arith.maxsi. Process both arguments.
+  // Current PtrState should be empty. See visitOperandMinMaxSI for semantics.
+  LogicalResult visitOperandMaxSI(arith::MaxSIOp maxOp, PtrState &state,
+                                  const Location loc, OpBuilder &builder);
 
   // Operand is the result of make_range.
   // Main assumptions:

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -886,6 +886,64 @@ LogicalResult PtrAnalysis::visitOperandExtSI(arith::ExtSIOp extOp,
   return visitOperand(extOp.getIn(), state, loc, builder);
 }
 
+LogicalResult PtrAnalysis::visitOperandMinMaxSI(Value lhs, Value rhs,
+                                                PtrState &state,
+                                                const Location loc,
+                                                OpBuilder &builder) {
+  PtrState lhsState;
+  if (visitOperand(lhs, lhsState, loc, builder).failed())
+    return failure();
+
+  PtrState rhsState;
+  if (visitOperand(rhs, rhsState, loc, builder).failed())
+    return failure();
+
+  // If one operand is a scalar bound and the other is a tensor of indices,
+  // propagate the tensor's state (the scalar is just a clamp bound).
+  if (lhsState.scalar && !rhsState.scalar && rhsState.getRank() > 0)
+    state = rhsState;
+  else if (rhsState.scalar && !lhsState.scalar && lhsState.getRank() > 0)
+    state = lhsState;
+  else if (lhsState.isStructured() && !rhsState.isStructured())
+    // Prefer the unstructured state for gather/scatter patterns.
+    state = rhsState;
+  else
+    // Default: use lhs state.
+    state = lhsState;
+
+  return success();
+}
+
+LogicalResult PtrAnalysis::visitOperandMinSI(arith::MinSIOp minOp,
+                                             PtrState &state,
+                                             const Location loc,
+                                             OpBuilder &builder) {
+  assert(state.isEmpty());
+  if (isAnalysisingUnstructured) {
+    assert(enableMakeGatherScatterTensorPtr &&
+           "PtrAnalysis: isAnalysisingUnstructured should only be true "
+           "when enableMakeGatherScatterTensorPtr is true");
+    return state.rebuildAsUnsupportedOp(minOp.getResult());
+  }
+  return visitOperandMinMaxSI(minOp.getLhs(), minOp.getRhs(), state, loc,
+                              builder);
+}
+
+LogicalResult PtrAnalysis::visitOperandMaxSI(arith::MaxSIOp maxOp,
+                                             PtrState &state,
+                                             const Location loc,
+                                             OpBuilder &builder) {
+  assert(state.isEmpty());
+  if (isAnalysisingUnstructured) {
+    assert(enableMakeGatherScatterTensorPtr &&
+           "PtrAnalysis: isAnalysisingUnstructured should only be true "
+           "when enableMakeGatherScatterTensorPtr is true");
+    return state.rebuildAsUnsupportedOp(maxOp.getResult());
+  }
+  return visitOperandMinMaxSI(maxOp.getLhs(), maxOp.getRhs(), state, loc,
+                              builder);
+}
+
 LogicalResult PtrAnalysis::visitOperandMakeRange(triton::MakeRangeOp rangeOp,
                                                  PtrState &state, Location loc,
                                                  OpBuilder &builder) {
@@ -1219,6 +1277,10 @@ LogicalResult PtrAnalysis::visitOperand(Value operand, PtrState &state,
     return visitOperandRem(op, state, loc, builder);
   } else if (auto op = operand.getDefiningOp<arith::ExtSIOp>()) {
     return visitOperandExtSI(op, state, loc, builder);
+  } else if (auto op = operand.getDefiningOp<arith::MinSIOp>()) {
+    return visitOperandMinSI(op, state, loc, builder);
+  } else if (auto op = operand.getDefiningOp<arith::MaxSIOp>()) {
+    return visitOperandMaxSI(op, state, loc, builder);
   } else if (auto op = operand.getDefiningOp<scf::ForOp>()) {
     return visitOperandForOp(op, operand, state, loc, builder);
   } else if (!operand.getDefiningOp()) {

--- a/test/Conversion/TritonToStructured/addptr_minsi_maxsi.mlir
+++ b/test/Conversion/TritonToStructured/addptr_minsi_maxsi.mlir
@@ -1,0 +1,97 @@
+// RUN: triton-shared-opt --triton-to-structured --remove-dead-values --canonicalize --split-input-file %s | FileCheck %s
+
+// Tests that arith.minsi and arith.maxsi used for bounds clamping in pointer
+// arithmetic are handled correctly by PtrAnalysis.
+//
+// The typical Triton pattern is:
+//   indices = tl.arange(0, BLOCK_SIZE)
+//   clamped = tl.minimum(indices, max_val)   # or tl.maximum(indices, min_val)
+//   ptr = base_ptr + clamped
+//
+// When one operand of min/max is a scalar bound and the other is a tensor of
+// indices, PtrAnalysis should propagate the tensor's PtrState (offset=0,
+// stride=1) and ignore the scalar bound, producing a structured tts.make_tptr.
+
+// Test 1: arith.minsi with scalar bound on RHS.
+module {
+  tt.func @minsi_scalar_rhs(%arg0: !tt.ptr<f32>, %arg1: i32) -> tensor<128xf32> {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %bound = tt.splat %arg1 : i32 -> tensor<128xi32>
+    %clamped = arith.minsi %range, %bound : tensor<128xi32>
+    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %ptr = tt.addptr %base, %clamped : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %data = tt.load %ptr : tensor<128x!tt.ptr<f32>>
+    tt.return %data : tensor<128xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func @minsi_scalar_rhs
+// CHECK:         [[PTR:%.+]] = tts.make_tptr %arg0 to sizes: [128], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<128x!tt.ptr<f32>>
+// CHECK:         "tts.load"([[PTR]])
+
+// -----
+
+// Test 2: arith.maxsi with scalar bound on LHS.
+module {
+  tt.func @maxsi_scalar_lhs(%arg0: !tt.ptr<f32>, %arg1: i32) -> tensor<128xf32> {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %bound = tt.splat %arg1 : i32 -> tensor<128xi32>
+    // scalar bound on lhs, range on rhs
+    %clamped = arith.maxsi %bound, %range : tensor<128xi32>
+    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %ptr = tt.addptr %base, %clamped : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %data = tt.load %ptr : tensor<128x!tt.ptr<f32>>
+    tt.return %data : tensor<128xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func @maxsi_scalar_lhs
+// CHECK:         [[PTR:%.+]] = tts.make_tptr %arg0 to sizes: [128], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<128x!tt.ptr<f32>>
+// CHECK:         "tts.load"([[PTR]])
+
+// -----
+
+// Test 3: Combined clamping — maxsi(minsi(range, hi), lo).
+// This is the typical clamp(x, lo, hi) pattern used in Triton kernels to
+// guard against out-of-bounds accesses.
+module {
+  tt.func @combined_clamp(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32) -> tensor<128xf32> {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %hi = tt.splat %arg1 : i32 -> tensor<128xi32>
+    %lo = tt.splat %arg2 : i32 -> tensor<128xi32>
+    // clamp to upper bound
+    %clamp_hi = arith.minsi %range, %hi : tensor<128xi32>
+    // clamp to lower bound
+    %clamp_lo = arith.maxsi %clamp_hi, %lo : tensor<128xi32>
+    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %ptr = tt.addptr %base, %clamp_lo : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %data = tt.load %ptr : tensor<128x!tt.ptr<f32>>
+    tt.return %data : tensor<128xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func @combined_clamp
+// CHECK:         [[PTR:%.+]] = tts.make_tptr %arg0 to sizes: [128], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<128x!tt.ptr<f32>>
+// CHECK:         "tts.load"([[PTR]])
+
+// -----
+
+// Test 4: arith.minsi with a constant splat (arith.constant dense<N>) on RHS.
+// This exercises the path where the scalar bound comes from a constant splat
+// rather than a tt.splat of a kernel argument.
+module {
+  tt.func @minsi_const_splat_rhs(%arg0: !tt.ptr<f32>) -> tensor<128xf32> {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    // constant splat: all elements are 64
+    %bound = arith.constant dense<64> : tensor<128xi32>
+    %clamped = arith.minsi %range, %bound : tensor<128xi32>
+    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %ptr = tt.addptr %base, %clamped : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %data = tt.load %ptr : tensor<128x!tt.ptr<f32>>
+    tt.return %data : tensor<128xf32>
+  }
+}
+
+// CHECK-LABEL: tt.func @minsi_const_splat_rhs
+// CHECK:         [[PTR:%.+]] = tts.make_tptr %arg0 to sizes: [128], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<128x!tt.ptr<f32>>
+// CHECK:         "tts.load"([[PTR]])


### PR DESCRIPTION
The PR updates the PtrState when the operands are min/max. This is similar to the support added for Mul/Rem/Add operands. For these specific operands the following is done,
```
When one operand of min/max is a scalar bound and the other is a tensor of
indices, PtrAnalysis should propagate the tensor's PtrState (offset=0,
stride=1) and ignore the scalar bound, producing a structured tts.make_tptr.
```