### PR TITLE
Update structured lowering pipeline

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -10,7 +10,6 @@ import hashlib
 import tempfile
 import os
 import re
-import shutil
 import subprocess
 import functools
 import triton
@@ -168,7 +167,23 @@ class CPUBackend(BaseBackend):
             print("Building with sanitizer support...")
             # has to run before the other passes as operates on the tt dialect
             triton_shared.add_llvm_debug_info(pm)
-        triton_shared.add_triton_to_linalg_experimental(pm)
+        triton_shared.add_triton_to_structured(pm, True)
+        passes.common.add_cse(pm)
+        passes.common.add_canonicalizer(pm)
+        triton_shared.add_triton_to_unstructured(pm)
+        triton_shared.add_triton_arith_to_linalg(pm, True)
+        triton_shared.add_structured_to_memref(pm)
+        triton_shared.add_unstructured_to_memref(pm)
+        triton_shared.add_triton_ptr_to_memref(pm)
+        triton_shared.add_triton_to_ptr(pm)
+        triton_shared.add_reconcile_unrealized_casts(pm)
+        triton_shared.add_reconcile_ptr_casts(pm)
+        triton_shared.add_remove_dead_code(pm)
+        passes.common.add_cse(pm)
+        passes.common.add_canonicalizer(pm)
+        if os.getenv("TRITON_SHARED_ENABLE_COLLAPSE_SHAPE", False):
+            print("Building with collapse-shape enabled ...")
+            triton_shared.add_collapse_shape(pm)
         pm.run(mod, 'make_tt_shared_ir')
         return mod
 

--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -297,13 +297,10 @@ def TTS_ScatterOp : TTS_Op<"scatter", [
   }];
 }
 
-def TTS_LoadOp : TTS_Op<"load", [
-  MemoryEffects<[MemRead]>,
-  AttrSizedOperandSegments
-]> {
+def TTS_LoadOp : TTS_Op<"load", [AttrSizedOperandSegments]> {
   let summary = "optionally load data from in memory to fill a portion of the tensor";
 
-  let arguments = (ins TT_PtrLike:$ptr,
+  let arguments = (ins Arg<TT_PtrLike, "", [MemRead]>:$ptr,
                        Variadic<Index>:$mask_dims,
                        DenseI64ArrayAttr:$static_mask_dims,
                        Optional<AnyTypeOf<[TT_Float, TT_Int, TT_Ptr]>>:$other);
@@ -331,12 +328,10 @@ def TTS_LoadOp : TTS_Op<"load", [
   //let hasVerifier = 1;
 }
 
-def TTS_StoreOp : TTS_Op<"store", [
-  MemoryEffects<[MemWrite]>
-]> {
+def TTS_StoreOp : TTS_Op<"store", []> {
   let summary = "optionally store data from in memory to fill a portion of the tensor";
 
-  let arguments = (ins TT_PtrLike:$ptr,
+  let arguments = (ins Arg<TT_PtrLike, "", [MemRead, MemWrite]>:$ptr,
                        TT_Tensor:$value,
                        Variadic<Index>:$mask_dims,
                        DenseI64ArrayAttr:$static_mask_dims);

--- a/triton_shared.cc
+++ b/triton_shared.cc
@@ -82,6 +82,22 @@ void init_triton_triton_shared(py::module &&m) {
 
   ADD_PASS_WRAPPER_0("add_triton_to_linalg_experimental",
                      triton::createTritonToLinalgExperimentalPass);
+  ADD_PASS_WRAPPER_1("add_triton_to_structured",
+                     triton::createTritonToStructuredPass, bool);
+  ADD_PASS_WRAPPER_0("add_triton_to_unstructured",
+                     triton::createTritonToUnstructuredPass);
+  ADD_PASS_WRAPPER_1("add_triton_arith_to_linalg",
+                     triton::createTritonArithToLinalgPass, bool);
+  ADD_PASS_WRAPPER_0("add_structured_to_memref",
+                     triton::createStructuredToMemrefPass);
+  ADD_PASS_WRAPPER_0("add_unstructured_to_memref",
+                     triton::createUnstructuredToMemrefPass);
+  ADD_PASS_WRAPPER_0("add_triton_ptr_to_memref",
+                     triton::createTritonPtrToMemrefPass);
+  ADD_PASS_WRAPPER_0("add_triton_to_ptr", triton::createTritonToPtrPass);
+  ADD_PASS_WRAPPER_0("add_reconcile_ptr_casts",
+                     triton::createReconcilePtrCastsPass);
+  ADD_PASS_WRAPPER_0("add_collapse_shape", triton::createCollapseShapePass);
 
   ADD_PASS_WRAPPER_0("add_llvm_debug_info", triton::createAddLLVMDebugInfoPass);
 
@@ -156,4 +172,5 @@ void init_triton_triton_shared(py::module &&m) {
 
   ADD_PASS_WRAPPER_0("add_reconcile_unrealized_casts",
                      mlir::createReconcileUnrealizedCastsPass);
+  ADD_PASS_WRAPPER_0("add_remove_dead_code", mlir::createRemoveDeadValuesPass);
 }


### PR DESCRIPTION
Replace the experimental Triton-to-Linalg lowering path with an explicit structured and unstructured lowering pipeline for the CPU backend.

Expose the required pass wrappers through the Python bindings and update TritonStructured load/store memory effect annotations for the new flow.