### PR TITLE
Support scf.if in structured pointer analysis

### DIFF
--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <set>
+#include <tuple>
 
 namespace mlir {
 
@@ -147,6 +148,20 @@ class PtrAnalysis {
       scf::ForOp forOp, size_t ptrArgIndex, const PtrState &state,
       llvm::function_ref<Value(scf::ForOp op, size_t)> getReplacementVal);
 
+  // Get the computed PtrState for the ifOp's result at the provided index.
+  FailureOr<PtrState> reconcileIfPtrState(scf::IfOp ifOp, size_t resIndex,
+                                          const PtrState &state);
+  FailureOr<PtrState> getBranchPtrState(scf::YieldOp yieldOp, size_t index);
+
+  // Analyze both branches of an scf.if and return
+  // {thenState, elseState, mergedState} for the result at the given index.
+  std::tuple<FailureOr<PtrState>, FailureOr<PtrState>, FailureOr<PtrState>>
+  getIfPtrState(scf::IfOp ifOp, size_t resIndex);
+
+  // get_structured_state ops under an scf.if with incompatible branch
+  // structuredness must be left untouched.
+  DenseSet<tts::GetStructuredStateOp> structuredStateOpsToSkip;
+
   DenseSet<Value> maybeStructuredArgs;
   const bool enableMakeGatherScatterTensorPtr;
   // If false, PtrAnalysis will analysis structured ptr while only identify
@@ -205,6 +220,10 @@ public:
   LogicalResult visitOperandForOp(scf::ForOp forOp, Value operand,
                                   PtrState &state, const Location loc,
                                   OpBuilder &builder);
+
+  // Operand is a result of an scf.if.
+  LogicalResult visitOperandIfOp(scf::IfOp ifOp, Value operand, PtrState &state,
+                                 const Location loc, OpBuilder &builder);
 
   // Operand is the result of arith.addi. Process both arguments and insert any
   // arith.addi instruction as needed.
@@ -353,6 +372,9 @@ public:
   // pointers over iterations. Insert any instruction needed to calculate
   // strides, offsets, and modulos.
   LogicalResult rewriteForOp(scf::ForOp op);
+
+  // Rewrite scf.if operations that return structured pointers.
+  LogicalResult rewriteIfOp(scf::IfOp op);
 
   LogicalResult rewriteLoadOp(triton::LoadOp op, bool useUnsafeMask = false);
 

--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h
@@ -11,15 +11,18 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Types.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace mlir {
 namespace tts {
 namespace utils {
+mlir::Type getSrcPtrType(mlir::Type type);
+bool hasPtrValue(mlir::Value value);
 mlir::Value getScalarValue(mlir::Value operand, mlir::Location loc,
                            mlir::OpBuilder &builder);
-}
+} // namespace utils
 } // namespace tts
 } // namespace mlir
 

--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -234,7 +234,7 @@ def TTS_GetStructuredStateOp : TTS_Op<"get_structured_state", [AttrSizedResultSe
   let description = "Used to pass the offsets and strides to scf.for op to simplify IR rewrites.";
 
   let arguments = (ins AnyTypeOf<[TT_PtrLike, I32Tensor]>:$input);
-  let results = (outs AnyTypeOf<[TT_PtrLike, I32Tensor]>:$structured, Variadic<Index>:$offsets, Variadic<Index>:$strides);
+  let results = (outs AnyTypeOf<[TT_PtrLike, I32Tensor]>:$structured, Variadic<Index>:$offsets, Variadic<Index>:$strides, TT_Ptr:$src);
 
   let builders = [
     OpBuilder<(ins "Value":$input)>,

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -34,6 +34,7 @@
 #include <optional>
 #include <queue>
 #include <string>
+#include <tuple>
 
 #define DEBUG_TYPE "triton-ptr-analysis"
 
@@ -209,9 +210,12 @@ LogicalResult PtrState::rebuildAsUnsupportedOp(Value operand) {
   if (!isEmpty())
     return failure();
 
-  // Scalar has been take care early.
-  // Assume here must be shape type.
-  auto opType = cast<ShapedType>(operand.getType());
+  // Scalar values have been handled earlier; unsupported fallback only applies
+  // to shaped values.
+  auto opType = dyn_cast<ShapedType>(operand.getType());
+  if (!opType) {
+    return failure();
+  }
   // Skip support for pointer types which could be source of PtrState.
   // This check avoids creating a PtrState with non-structured source.
   if (isa<triton::PointerType>(opType.getElementType()))
@@ -269,14 +273,16 @@ LogicalResult PtrState::addState(const PtrState &lhsState,
   assert(isEmpty() && lhsState.getRank() == rhsState.getRank());
   auto loc = op->getLoc();
 
-  if (lhsState.source && rhsState.source) {
+  bool lhsHasSource = utils::hasPtrValue(lhsState.source);
+  bool rhsHasSource = utils::hasPtrValue(rhsState.source);
+  if (lhsHasSource && rhsHasSource) {
     LLVM_DEBUG(op->emitRemark(
         "PtrAnalysis: do not support adding two pointer states that both "
         "have base pointers"));
     return failure();
   }
 
-  source = lhsState.source ? lhsState.source : rhsState.source;
+  source = lhsHasSource ? lhsState.source : rhsState.source;
 
   if (lhsState.scalar && rhsState.scalar) {
     auto addOp =
@@ -535,7 +541,9 @@ LogicalResult PtrState::mulState(const PtrState &lhsState,
 
   // neither lhs nor rhs should have source, since multiplying base pointer
   // does not make sense
-  if (lhsState.source && rhsState.source) {
+  bool lhsHasSource = utils::hasPtrValue(lhsState.source);
+  bool rhsHasSource = utils::hasPtrValue(rhsState.source);
+  if (lhsHasSource && rhsHasSource) {
     LLVM_DEBUG(op->emitRemark(
         "PtrAnalysis: do not support multiplying base pointers"));
     return failure();
@@ -1186,6 +1194,8 @@ LogicalResult PtrAnalysis::visitOperand(Value operand, PtrState &state,
       } else if (auto intToPtrOp = dyn_cast<triton::IntToPtrOp>(op)) {
         return visitOperandIntToPtr(intToPtrOp, state, loc, builder);
       } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        return visitOperandIfOp(ifOp, operand, state, loc, builder);
+      } else if (isa<arith::SelectOp>(op)) {
         state.source = operand;
         return success();
       } else {
@@ -1221,6 +1231,8 @@ LogicalResult PtrAnalysis::visitOperand(Value operand, PtrState &state,
     return visitOperandExtSI(op, state, loc, builder);
   } else if (auto op = operand.getDefiningOp<scf::ForOp>()) {
     return visitOperandForOp(op, operand, state, loc, builder);
+  } else if (auto op = operand.getDefiningOp<scf::IfOp>()) {
+    return visitOperandIfOp(op, operand, state, loc, builder);
   } else if (!operand.getDefiningOp()) {
     if (!knownPtrs.contains(operand)) {
       return failure();
@@ -1304,7 +1316,10 @@ static bool isPointerType(Type t) {
   if (auto tensor = llvm::dyn_cast<RankedTensorType>(t)) {
     return isa<triton::PointerType>(tensor.getElementType());
   }
-  return isa<triton::PointerType>(t);
+  if (auto ptr = dyn_cast<triton::PointerType>(t)) {
+    return !isa<NoneType>(ptr.getPointeeType());
+  }
+  return false;
 }
 
 FailureOr<PtrState> PtrAnalysis::getLoopInitArgPtrState(scf::ForOp forOp,
@@ -1347,7 +1362,8 @@ FailureOr<PtrState> PtrAnalysis::getLoopInitArgPtrState(scf::ForOp forOp,
   }
 
   // If the pointer isn't defined by tts.get_structured_state nor another loop,
-  // it means the current pointer is an iterarg of the outer loop.
+  // it means the current pointer is an iterarg of the outer loop or a pointer
+  // returned by another construct such as an scf.if.
   // In such cases, the outer loops would have already set up the PtrState for
   // us already.
   //
@@ -1357,7 +1373,6 @@ FailureOr<PtrState> PtrAnalysis::getLoopInitArgPtrState(scf::ForOp forOp,
   //    }
   // }
   if (knownPtrs.count(ptr)) {
-    assert(!ptr.getDefiningOp() && "Expect the ptr to be an iterarg");
     return knownPtrs[ptr];
   }
 
@@ -1370,7 +1385,6 @@ PtrState PtrAnalysis::reconcileLoopPtrState(
   PtrState newState = state;
   int cnt = iterArgIndex + 1;
   if (newState.getRank() == 0) {
-    assert(newState.scalar);
     // for scalar pointers, the scalar contains the offset and is the only
     // relevant newState that could be updated by the loop.
     newState.scalar = getReplacementVal(forOp, cnt);
@@ -1420,6 +1434,145 @@ FailureOr<PtrState> PtrAnalysis::getLoopResultPtrState(scf::ForOp forOp,
       [](scf::ForOp op, size_t index) { return op->getResult(index); });
 }
 
+FailureOr<PtrState> PtrAnalysis::reconcileIfPtrState(scf::IfOp ifOp,
+                                                     size_t resIndex,
+                                                     const PtrState &state) {
+  PtrState newState = state;
+  size_t cnt = resIndex + 1;
+  if (newState.getRank() == 0) {
+    assert(resIndex + 2 < ifOp.getNumResults() &&
+           "if op does not return enough pointer state results");
+    newState.scalar = ifOp.getResult(cnt++);
+  } else {
+    assert(resIndex + newState.getRank() * 2 + 1 < ifOp.getNumResults() &&
+           "if op does not return enough pointer state results");
+    for (auto &offset : newState.offsets) {
+      offset = ifOp.getResult(cnt++);
+    }
+    for (auto &stride : newState.strides) {
+      stride = ifOp.getResult(cnt++);
+    }
+  }
+
+  newState.source = ifOp.getResult(cnt++);
+  return newState;
+}
+
+FailureOr<PtrState> PtrAnalysis::getBranchPtrState(scf::YieldOp yieldOp,
+                                                   size_t index) {
+  Value ptr = yieldOp.getOperand(index);
+  if (auto getStateOp = ptr.getDefiningOp<tts::GetStructuredStateOp>()) {
+    ptr = getStateOp->getOperand(0);
+  }
+  if (knownPtrs.count(ptr)) {
+    return knownPtrs[ptr];
+  }
+  return failure();
+}
+
+std::tuple<FailureOr<PtrState>, FailureOr<PtrState>, FailureOr<PtrState>>
+PtrAnalysis::getIfPtrState(scf::IfOp ifOp, size_t resIndex) {
+  assert(resIndex < ifOp.getNumResults());
+
+  FailureOr<PtrState> thenState = getBranchPtrState(ifOp.thenYield(), resIndex);
+  FailureOr<PtrState> elseState = getBranchPtrState(ifOp.elseYield(), resIndex);
+
+  bool thenSucceeded = succeeded(thenState) && thenState->isStructured();
+  bool elseSucceeded = succeeded(elseState) && elseState->isStructured();
+
+  if (!thenSucceeded && !elseSucceeded) {
+    LLVM_DEBUG(ifOp->emitRemark(
+        "PtrAnalysis: result from both branches is not structured"));
+    return {failure(), failure(), failure()};
+  }
+
+  if (thenSucceeded != elseSucceeded) {
+    LLVM_DEBUG(ifOp->emitRemark("PtrAnalysis: result from one branch is "
+                                "structured but the other is not"));
+    return {thenState, elseState, failure()};
+  }
+
+  if (thenState->hasModulo() || elseState->hasModulo()) {
+    LLVM_DEBUG(
+        ifOp->emitRemark("PtrAnalysis: do not support modulo with if op"));
+    return {thenState, elseState, failure()};
+  }
+
+  FailureOr<PtrState> mergedState =
+      reconcileIfPtrState(ifOp, resIndex, *thenState);
+  return {thenState, elseState, mergedState};
+}
+
+LogicalResult PtrAnalysis::visitOperandIfOp(scf::IfOp ifOp, Value operand,
+                                            PtrState &state, const Location loc,
+                                            OpBuilder &builder) {
+  auto resultIt = llvm::find(ifOp->getResults(), operand);
+  if (resultIt == ifOp->getResults().end()) {
+    LLVM_DEBUG(
+        ifOp->emitRemark("PtrAnalysis: operand is not a result of the if op"));
+    return failure();
+  }
+
+  size_t resIndex = std::distance(ifOp->getResults().begin(), resultIt);
+  FailureOr<PtrState> mergedState;
+  std::tie(std::ignore, std::ignore, mergedState) =
+      getIfPtrState(ifOp, resIndex);
+  if (failed(mergedState)) {
+    if (enableMakeGatherScatterTensorPtr &&
+        succeeded(state.rebuildAsUnsupportedOp(operand))) {
+      return success();
+    }
+    LLVM_DEBUG(ifOp->emitRemark(
+        "PtrAnalysis: failed to get pointer state for if op result"));
+    return failure();
+  }
+
+  state = *mergedState;
+  return success();
+}
+
+LogicalResult PtrAnalysis::rewriteIfOp(scf::IfOp op) {
+  if (failed(rewriteOp(op))) {
+    LLVM_DEBUG(llvm::dbgs() << "Failed to rewrite all ops inside if op\n");
+  }
+
+  SmallVector<std::pair<Value, PtrState>, 4> structuredPointers;
+  for (auto [resultIndex, result] : llvm::enumerate(op.getResults())) {
+    if (!maybeStructuredArgs.contains(result)) {
+      continue;
+    }
+
+    auto [thenState, elseState, mergedState] = getIfPtrState(op, resultIndex);
+    if (failed(thenState) && failed(elseState)) {
+      continue;
+    }
+
+    if (failed(mergedState)) {
+      op.walk([&](tts::GetStructuredStateOp getStateOp) {
+        structuredStateOpsToSkip.insert(getStateOp);
+      });
+      return success();
+    }
+
+    structuredPointers.push_back({result, *mergedState});
+  }
+
+  if (!structuredPointers.empty()) {
+    OpBuilder builder(op);
+    builder.setInsertionPointAfter(op);
+    for (auto [result, state] : structuredPointers) {
+      if (state.getRank() != 0) {
+        auto makeTensorPtrOp =
+            state.createTTSMakeTensorPtrOp(builder, op.getLoc());
+        ptrMap.map(result, makeTensorPtrOp.getResult());
+      }
+      knownPtrs[result] = state;
+    }
+  }
+
+  return success();
+}
+
 LogicalResult PtrAnalysis::rewriteForOp(scf::ForOp op) {
   for (auto [i, arg] : llvm::enumerate(op.getRegionIterArgs())) {
     if (!maybeStructuredArgs.contains(arg)) {
@@ -1427,7 +1580,10 @@ LogicalResult PtrAnalysis::rewriteForOp(scf::ForOp op) {
     }
 
     auto state = getLoopIterArgPtrState(op, i);
-    if (failed(state)) {
+    auto loopResultState = getLoopResultPtrState(op, i);
+    assert(failed(state) == failed(loopResultState) &&
+           "loop argument and result states should agree");
+    if (failed(state) || failed(loopResultState)) {
       // Because the maybeStructuredArgs may contain values that are not
       // considered structured by PtrAnalysis, failing to retrieve the PtrState
       // should not fail the rewrite process.
@@ -1443,6 +1599,7 @@ LogicalResult PtrAnalysis::rewriteForOp(scf::ForOp op) {
 
     // Save the current init arg's PtrState
     knownPtrs[arg] = state.value();
+    knownPtrs[op.getResult(i)] = loopResultState.value();
 
     // For tensors of pointers, create a tts.make_tptr at the beginning of the
     // loop body that correspond to this region iter arg. In case it is used
@@ -1474,6 +1631,12 @@ LogicalResult PtrAnalysis::rewriteForOp(scf::ForOp op) {
         OpBuilder builder(op.getRegion());
         auto maketptrOp = state->createTTSMakeTensorPtrOp(builder, op.getLoc());
         ptrMap.map(arg, maketptrOp.getResult());
+
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointAfter(op);
+        auto loopPtr =
+            loopResultState->createTTSMakeTensorPtrOp(builder, op.getLoc());
+        ptrMap.map(op.getResult(i), loopPtr.getResult());
       }
     }
   }
@@ -1502,6 +1665,12 @@ PtrAnalysis::rewriteGetStructuredStateOp(tts::GetStructuredStateOp op) {
     return failure();
   }
 
+  if (structuredStateOpsToSkip.contains(op)) {
+    LLVM_DEBUG(op.emitRemark("Skip rewriting GetStructuredStateOp."));
+    op.getResult(0).replaceAllUsesWith(tritonValue);
+    return success();
+  }
+
   tts::PtrState state = knownPtrs[tritonValue];
   if (!state.isStructured()) {
     LLVM_DEBUG(op.emitRemark(
@@ -1521,9 +1690,9 @@ PtrAnalysis::rewriteGetStructuredStateOp(tts::GetStructuredStateOp op) {
     if (state.scalar) {
       replacements.push_back(state.scalar);
     } else {
-      // This operand is a pointer directly from the kernel arguments.
+      // This operand is a pointer directly from the kernel arguments or from
+      // another operation that returns a pointer.
       // Use offset 0.
-      assert(!tritonValue.getDefiningOp());
       replacements.push_back(arith::ConstantOp::create(
           builder, op.getLoc(), builder.getIndexAttr(0)));
     }
@@ -1549,6 +1718,18 @@ PtrAnalysis::rewriteGetStructuredStateOp(tts::GetStructuredStateOp op) {
         replacements.push_back(cast<Value>(s));
       }
     }
+  }
+
+  if (state.source) {
+    replacements.push_back(state.source);
+  } else {
+    replacements.push_back(
+        UnrealizedConversionCastOp::create(
+            builder,
+            op.getLoc(),
+            triton::PointerType::get(NoneType::get(op.getContext()), 1),
+            ValueRange{})
+            .getResult(0));
   }
 
   op->replaceAllUsesWith(replacements);
@@ -1681,6 +1862,23 @@ void PtrAnalysis::initializeMaybeStructuredArgs(Operation *op) {
             }
           }
         }
+      } else if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+        auto parentIf = dyn_cast<scf::IfOp>(yieldOp->getParentOp());
+        if (!parentIf) {
+          continue;
+        }
+        for (auto [yieldIdx, yieldOperand] :
+             llvm::enumerate(yieldOp.getOperands())) {
+          if (yieldOperand != v) {
+            continue;
+          }
+          Value ifResult = parentIf->getResult(yieldIdx);
+          maybeStructuredArgs.insert(ifResult);
+          if (!visited.contains(ifResult)) {
+            visited.insert(ifResult);
+            q.push(ifResult);
+          }
+        }
       } else {
         for (auto res : user->getResults()) {
           if (res.getType() != v.getType()) {
@@ -1790,6 +1988,12 @@ LogicalResult PtrAnalysis::rewriteOp(Operation *rootOp, bool useUnsafeMask) {
           if (rewriteForOp(forOp).failed()) {
             LLVM_DEBUG(
                 forOp->emitRemark("PtrAnalysis: Failed to rewrite ForOp"));
+          }
+          return WalkResult::skip();
+        })
+        .Case<scf::IfOp>([&](auto ifOp) {
+          if (rewriteIfOp(ifOp).failed()) {
+            LLVM_DEBUG(ifOp->emitRemark("PtrAnalysis: Failed to rewrite IfOp"));
           }
           return WalkResult::skip();
         })

--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -58,6 +58,7 @@ class TritonToStructuredPass
         *tts::GetStructuredStateOp::getOffsetAndStrideTypes(context, t);
     tupleTypes.append(offsetTypes);
     tupleTypes.append(strideTypes);
+    tupleTypes.push_back(tts::utils::getSrcPtrType(t));
     return TupleType::get(context, tupleTypes);
   }
 
@@ -91,8 +92,10 @@ public:
       // because only values of int and index type can potentially be part of a
       // pointer arithmetic sequence.
       auto elementType = tensorType.getElementType();
+      // Keep this in sync with TT_IndexTensorLike, which only accepts i32/i64
+      // tensors as structured-state operands.
       if (isa<triton::PointerType>(elementType) ||
-          (elementType.isIntOrIndex() && !elementType.isInteger(1))) {
+          elementType.isInteger(32) || elementType.isInteger(64)) {
         types =
             SmallVector<Type>{getStructuredStateTupleType(context, tensorType)};
         return success();
@@ -182,8 +185,8 @@ public:
     // maps to a sequence of {pointer, offset_0, offset_1,..., stride_0,
     // stride_1,...}
     converter.addConversion(
-        [](TupleType tupleType, SmallVectorImpl<Type> &types)
-            -> std::optional<LogicalResult> {
+        [](TupleType tupleType,
+           SmallVectorImpl<Type> &types) -> std::optional<LogicalResult> {
           tupleType.getFlattenedTypes(types);
           return success();
         });

--- a/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
+++ b/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
@@ -36,6 +36,34 @@ namespace mlir {
 namespace tts {
 
 namespace utils {
+Type getSrcPtrType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+    if (auto ptrType =
+            dyn_cast<triton::PointerType>(tensorType.getElementType())) {
+      return ptrType;
+    }
+  }
+  if (auto ptrType = dyn_cast<triton::PointerType>(type)) {
+    if (auto tensorType =
+            dyn_cast<RankedTensorType>(ptrType.getPointeeType())) {
+      return triton::PointerType::get(tensorType.getElementType(),
+                                      ptrType.getAddressSpace());
+    }
+    return ptrType;
+  }
+  return triton::PointerType::get(NoneType::get(type.getContext()), 1);
+}
+
+bool hasPtrValue(Value value) {
+  if (!value) {
+    return false;
+  }
+  if (auto ptrType = dyn_cast<triton::PointerType>(value.getType())) {
+    return !isa<NoneType>(ptrType.getPointeeType());
+  }
+  return false;
+}
+
 // Extract a scalar value from v.
 // If v is a scalar, return that directly. Otherwise, parse through operations
 // (currently only support splat, sitofp, and truncf) that produce it to
@@ -345,16 +373,26 @@ LogicalResult GetStructuredStateOp::verify() {
       getOffsetAndStrideTypes(getContext(), getInput().getType());
 
   if (!expectedOffsetAndStrideTypes.has_value()) {
-    return failure();
+    return emitOpError("invalid input type for get_structured_state");
   }
 
   auto [expectedOffsetTypes, expectedStrideTypes] =
       *expectedOffsetAndStrideTypes;
 
-  return success(expectedOffsetTypes.size() == getOffsets().size() &&
-                 llvm::equal(expectedOffsetTypes, getOffsets().getTypes()) &&
-                 expectedStrideTypes.size() == getStrides().size() &&
-                 llvm::equal(expectedStrideTypes, getStrides().getTypes()));
+  bool offsetTypesMatch =
+      expectedOffsetTypes.size() == getOffsets().size() &&
+      llvm::equal(expectedOffsetTypes, getOffsets().getTypes());
+  bool strideTypesMatch =
+      expectedStrideTypes.size() == getStrides().size() &&
+      llvm::equal(expectedStrideTypes, getStrides().getTypes());
+  bool srcTypeMatches =
+      getSrc().getType() == utils::getSrcPtrType(getInput().getType());
+
+  if (!offsetTypesMatch || !strideTypesMatch || !srcTypeMatches) {
+    return emitOpError(
+        "verification of operation 'tts.get_structured_state' failed");
+  }
+  return success();
 }
 
 void GetStructuredStateOp::build(OpBuilder &b, OperationState &state,
@@ -367,7 +405,8 @@ void GetStructuredStateOp::build(OpBuilder &b, OperationState &state,
       getOffsetAndStrideTypes(b.getContext(), type)
           .value_or(std::make_pair(SmallVector<Type>{}, SmallVector<Type>{}));
 
-  build(b, state, val.getType(), offsetTypes, strideTypes, val);
+  build(b, state, val.getType(), offsetTypes, strideTypes,
+        utils::getSrcPtrType(val.getType()), val);
 }
 
 std::optional<std::pair<SmallVector<Type>, SmallVector<Type>>>

--- a/test/Conversion/TritonToLinalgExperimental/conditional_ptr_as_src.mlir
+++ b/test/Conversion/TritonToLinalgExperimental/conditional_ptr_as_src.mlir
@@ -28,29 +28,22 @@ module {
 
 // CHECK-LABEL:   func.func @simple_cf_into_structured_load(
 // CHECK-SAME:      %[[ARG0:.*]]: memref<*xf32>, %[[ARG1:.*]]: memref<*xf32>, %[[ARG2:.*]]: i32, %[[ARG3:.*]]: i32, %[[ARG4:.*]]: i32, %[[ARG5:.*]]: i32, %[[ARG6:.*]]: i32, %[[ARG7:.*]]: i32, %[[ARG8:.*]]: i32) {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2 : i32
-// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i32
-// CHECK:           %[[CAST_0:.*]] = memref.cast %[[ARG0]] : memref<*xf32> to memref<1xf32>
-// CHECK:           %[[MEMORY_SPACE_CAST_0:.*]] = memref.memory_space_cast %[[CAST_0]] : memref<1xf32> to memref<1xf32, #tptr.default_memory_space>
-// CHECK:           %[[TO_PTR_0:.*]] = ptr.to_ptr %[[MEMORY_SPACE_CAST_0]] : memref<1xf32, #tptr.default_memory_space> -> <#tptr.default_memory_space>
-// CHECK:           %[[CMPI_0:.*]] = arith.cmpi eq, %[[ARG2]], %[[CONSTANT_1]] : i32
-// CHECK:           %[[IF_0:.*]] = scf.if %[[CMPI_0]] -> (!ptr.ptr<#tptr.default_memory_space>) {
-// CHECK:             %[[MULI_0:.*]] = arith.muli %[[ARG2]], %[[CONSTANT_0]] : i32
-// CHECK:             %[[TYPE_OFFSET_0:.*]] = ptr.type_offset f32 : i32
-// CHECK:             %[[MULI_1:.*]] = arith.muli %[[MULI_0]], %[[TYPE_OFFSET_0]] : i32
-// CHECK:             %[[PTR_ADD_0:.*]] = ptr.ptr_add %[[TO_PTR_0]], %[[MULI_1]] : !ptr.ptr<#tptr.default_memory_space>, i32
-// CHECK:             scf.yield %[[PTR_ADD_0]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 6 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2 : i32
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[CMPI_0:.*]] = arith.cmpi eq, %[[ARG2]], %[[CONSTANT_2]] : i32
+// CHECK:           %[[IF_0:.*]] = scf.if %[[CMPI_0]] -> (index) {
+// CHECK:             %[[MULI_0:.*]] = arith.muli %[[ARG2]], %[[CONSTANT_1]] : i32
+// CHECK:             %[[INDEX_CAST_0:.*]] = arith.index_cast %[[MULI_0]] : i32 to index
+// CHECK:             scf.yield %[[INDEX_CAST_0]] : index
 // CHECK:           } else {
-// CHECK:             %[[TYPE_OFFSET_1:.*]] = ptr.type_offset f32 : i32
-// CHECK:             %[[MULI_2:.*]] = arith.muli %[[ARG2]], %[[TYPE_OFFSET_1]] : i32
-// CHECK:             %[[PTR_ADD_1:.*]] = ptr.ptr_add %[[TO_PTR_0]], %[[MULI_2]] : !ptr.ptr<#tptr.default_memory_space>, i32
-// CHECK:             scf.yield %[[PTR_ADD_1]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:             %[[INDEX_CAST_1:.*]] = arith.index_cast %[[ARG2]] : i32 to index
+// CHECK:             scf.yield %[[INDEX_CAST_1]] : index
 // CHECK:           }
-// CHECK:           %[[FROM_PTR_0:.*]] = ptr.from_ptr %[[IF_0]] : <#tptr.default_memory_space> -> memref<1xf32, #tptr.default_memory_space>
-// CHECK:           %[[MEMORY_SPACE_CAST_1:.*]] = memref.memory_space_cast %[[FROM_PTR_0]] : memref<1xf32, #tptr.default_memory_space> to memref<1xf32>
-// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[MEMORY_SPACE_CAST_1]] to offset: [6], sizes: [4], strides: [1] : memref<1xf32> to memref<4xf32, strided<[1], offset: 6>>
+// CHECK:           %[[ADDI_0:.*]] = arith.addi %[[IF_0]], %[[CONSTANT_0]] : index
+// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [%[[ADDI_0]]], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
 // CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<4xf32>
-// CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<4xf32, strided<[1], offset: 6>> to memref<4xf32>
+// CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<4xf32, strided<[1], offset: ?>> to memref<4xf32>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<4xf32> to tensor<4xf32>
 // CHECK:           %[[REINTERPRET_CAST_1:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: [0], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1]>>
 // CHECK:           bufferization.materialize_in_destination %[[TO_TENSOR_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<4xf32>, memref<4xf32, strided<[1]>>) -> ()

--- a/test/Conversion/TritonToStructured/arith_select_ptr.mlir
+++ b/test/Conversion/TritonToStructured/arith_select_ptr.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-shared-opt --triton-to-structured --remove-dead-values --canonicalize %s
+
+// Goal of this test is just to not crash on ops that are unsupported by
+// PtrAnalysis like arith.select.
+
+module {
+  tt.func public @concat_2D_jagged(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg3: i64, %arg4: i64) attributes {noinline = false} {
+    %cst = arith.constant dense<256> : tensor<1x1xi64>
+    %0 = arith.cmpi slt, %arg3, %arg4 : i64
+    %1 = arith.select %0, %arg0, %arg1 : !tt.ptr<bf16>
+    %2 = tt.splat %1 : !tt.ptr<bf16> -> tensor<1x256x!tt.ptr<bf16>>
+    %3 = tt.splat %arg3 : i64 -> tensor<1x1xi64>
+    %4 = arith.muli %3, %cst : tensor<1x1xi64>
+    %5 = tt.broadcast %4 : tensor<1x1xi64> -> tensor<1x256xi64>
+    %6 = tt.addptr %2, %5 : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi64>
+    %7 = tt.load %6 : tensor<1x256x!tt.ptr<bf16>>
+    %8 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<1x256x!tt.ptr<bf16>>
+    tt.store %8, %7 : tensor<1x256x!tt.ptr<bf16>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/conditional_block_ptr_as_src.mlir
+++ b/test/Conversion/TritonToStructured/conditional_block_ptr_as_src.mlir
@@ -1,0 +1,76 @@
+// RUN: triton-shared-opt --triton-to-structured %s | FileCheck %s
+
+module {
+  tt.func public @tensor_pointer_in_conditional_kernel(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %arg3: i32) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c16_i32 : i32
+    %2 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %3 = tt.splat %1 : i32 -> tensor<16xi32>
+    %4 = arith.addi %3, %2 : tensor<16xi32>
+    %5 = arith.cmpi ne, %arg3, %c0_i32 : i32
+    %6 = scf.if %5 -> (tensor<16x!tt.ptr<f16>>) {
+      %10 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %11 = tt.addptr %10, %4 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      scf.yield %11 : tensor<16x!tt.ptr<f16>>
+    } else {
+      %10 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %11 = tt.addptr %10, %4 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      scf.yield %11 : tensor<16x!tt.ptr<f16>>
+    }
+    %7 = tt.load %6 : tensor<16x!tt.ptr<f16>>
+    %8 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %9 = tt.addptr %8, %4 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    tt.store %9, %7 : tensor<16x!tt.ptr<f16>>
+    tt.return
+  }
+
+// CHECK:         tt.func public @tensor_pointer_in_conditional_kernel([[PARAM_0_:%.+]]: !tt.ptr<f16>, [[PARAM_1_:%.+]]: !tt.ptr<f16>, [[PARAM_2_:%.+]]: !tt.ptr<f16>, [[PARAM_3_:%.+]]: i32)
+// CHECK:           [[VAR_0_:%.+]] = arith.cmpi ne
+// CHECK:           [[VAR_1_:%.+]]:4 = scf.if [[VAR_0_]] -> (tensor<16x!tt.ptr<f16>>, index, index, !tt.ptr<f16>) {
+// CHECK:           } else {
+// CHECK:           }
+// CHECK:           [[VAR_2_:%.+]] = tts.make_tptr [[VAR_1_]]#3 to sizes: [16], strides: [[[VAR_1_]]#2], offsets: [[[VAR_1_]]#1], shape: [0], order: [] : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:           "tts.load"([[VAR_2_]])
+
+  tt.func public @tensor_pointer_in_nested_conditional_kernel(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %arg3: i32, %arg4: i32) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c16_i32 : i32
+    %2 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %3 = tt.splat %1 : i32 -> tensor<16xi32>
+    %4 = arith.addi %3, %2 : tensor<16xi32>
+    %5 = arith.cmpi ne, %arg3, %c0_i32 : i32
+    %6 = scf.if %5 -> (tensor<16x!tt.ptr<f16>>) {
+      %10 = arith.cmpi ne, %arg4, %c0_i32 : i32
+      %11 = scf.if %10 -> (tensor<16x!tt.ptr<f16>>) {
+        %12 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+        scf.yield %12 : tensor<16x!tt.ptr<f16>>
+      } else {
+        %12 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+        %13 = tt.addptr %12, %4 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+        scf.yield %13 : tensor<16x!tt.ptr<f16>>
+      }
+      scf.yield %11 : tensor<16x!tt.ptr<f16>>
+    } else {
+      %10 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %11 = tt.addptr %10, %4 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      scf.yield %11 : tensor<16x!tt.ptr<f16>>
+    }
+    %7 = tt.load %6 : tensor<16x!tt.ptr<f16>>
+    %8 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %9 = tt.addptr %8, %4 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    tt.store %9, %7 : tensor<16x!tt.ptr<f16>>
+    tt.return
+  }
+
+// CHECK:         tt.func public @tensor_pointer_in_nested_conditional_kernel([[PARAM_0_:%.+]]: !tt.ptr<f16>, [[PARAM_1_:%.+]]: !tt.ptr<f16>, [[PARAM_2_:%.+]]: !tt.ptr<f16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32)
+// CHECK:           [[VAR_0_:%.+]] = arith.cmpi ne
+// CHECK:           [[VAR_1_:%.+]]:4 = scf.if [[VAR_0_]] -> (tensor<16x!tt.ptr<f16>>, index, index, !tt.ptr<f16>) {
+// CHECK:           } else {
+// CHECK:           }
+// CHECK:           [[VAR_2_:%.+]] = tts.make_tptr [[VAR_1_]]#3 to sizes: [16], strides: [[[VAR_1_]]#2], offsets: [[[VAR_1_]]#1], shape: [0], order: [] : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:           "tts.load"([[VAR_2_]])
+}

--- a/test/Conversion/TritonToStructured/conditional_ptr_as_src.mlir
+++ b/test/Conversion/TritonToStructured/conditional_ptr_as_src.mlir
@@ -24,12 +24,34 @@ module {
     tt.store %8, %6 : tensor<4x!tt.ptr<f32>>
     tt.return
   }
+
+  tt.func public @select_into_structured_load(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: !tt.ptr<f32>) attributes {noinline = false} {
+    %c6_i32 = arith.constant 6 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = arith.cmpi eq, %arg2, %c1_i32 : i32
+    %1 = arith.select %0, %arg0, %arg3 : !tt.ptr<f32>
+    %2 = tt.addptr %1, %c6_i32 : !tt.ptr<f32>, i32
+    %3 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %4 = tt.splat %2 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %3 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    %6 = tt.load %5 : tensor<4x!tt.ptr<f32>>
+    %7 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %3 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %8, %6 : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
 }
 
 // CHECK:         tt.func public @simple_cf_into_structured_load([[PARAM_0_:%.+]]: !tt.ptr<f32>, [[PARAM_1_:%.+]]: !tt.ptr<f32>, [[PARAM_2_:%.+]]: i32) attributes {noinline = false} {
 // CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.cmpi eq
-// CHECK-DAG:       [[VAR_1_:%.+]] = scf.if [[VAR_0_]] -> (!tt.ptr<f32>) {
+// CHECK-DAG:       [[VAR_1_:%.+]] = scf.if [[VAR_0_]] -> (index) {
 // CHECK:           } else {
 // CHECK:           }
-// CHECK:           tts.make_tptr [[VAR_1_]] to sizes: [4], strides: [1], offsets: {{.}}[[CST_6_]]{{.}}, shape: [0], order: [] : <f32> to tensor<4x!tt.ptr<f32>>
+// CHECK:           [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_6_]] : index
+// CHECK:           tts.make_tptr [[PARAM_0_]] to sizes: [4], strides: [1], offsets: {{.}}[[VAR_2_]]{{.}}, shape: [0], order: [] : <f32> to tensor<4x!tt.ptr<f32>>
+
+// CHECK:         tt.func public @select_into_structured_load([[PARAM_0_:%.+]]: !tt.ptr<f32>, [[PARAM_1_:%.+]]: !tt.ptr<f32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: !tt.ptr<f32>) attributes {noinline = false} {
+// CHECK:           [[VAR_0_:%.+]] = arith.cmpi eq
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.select [[VAR_0_]], [[PARAM_0_]], [[PARAM_3_]] : !tt.ptr<f32>
+// CHECK:           tts.make_tptr [[VAR_1_]] to sizes: [4], strides: [1], offsets: [{{%c6|6}}], shape: [0], order: [] : <f32> to tensor<4x!tt.ptr<f32>>

--- a/test/Conversion/TritonToStructured/get_structured_state.mlir
+++ b/test/Conversion/TritonToStructured/get_structured_state.mlir
@@ -1,0 +1,23 @@
+// RUN: triton-shared-opt %s -split-input-file --verify-diagnostics
+
+// Test that a tts.get_structured_state op on a real pointer value cannot return a pointer<none>
+
+module {
+  tt.func public @invalid_ptr_to_none(%arg0: tensor<16x!tt.ptr<f32>>) {
+    // expected-error@below {{verification of operation 'tts.get_structured_state' failed}}
+    %0, %1, %2, %3 = "tts.get_structured_state"(%arg0) <{resultSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<16x!tt.ptr<f32>>) -> (tensor<16x!tt.ptr<f32>>, index, index, !tt.ptr<none>)
+    tt.return
+  }
+}
+
+// -----
+
+// Test that a tts.get_structured_state op on a tensor of indices cannot return a pointer of non-none type
+
+module {
+  tt.func public @invalid_indices_to_ptr(%arg0: tensor<16xi32>) {
+    // expected-error@below {{verification of operation 'tts.get_structured_state' failed}}
+    %0, %1, %2, %3 = "tts.get_structured_state"(%arg0) <{resultSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<16xi32>) -> (tensor<16xi32>, index, index, !tt.ptr<f32>)
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/get_structured_state_int_element_types.mlir
+++ b/test/Conversion/TritonToStructured/get_structured_state_int_element_types.mlir
@@ -1,0 +1,71 @@
+// RUN: triton-shared-opt --triton-to-structured="run-prepass-only=true" --split-input-file %s | FileCheck %s
+
+// The TritonToStructured prepass inserts tts.get_structured_state around
+// scf.for iter_args whose type the converter treats as "structured". The
+// converter must only treat pointer tensors and i32/i64 integer tensors as
+// structured -- TT_IndexTensorLike in TritonStructuredDialect.td is defined
+// as AnyTypeOf<[I32Tensor, I64Tensor]>, so wrapping a tensor with any other
+// integer/index element type produces an op that fails verification.
+//
+// These tests pin the pass behavior on the boundary: the pointer iter_arg is
+// expected to be wrapped (one tts.get_structured_state before the loop, one
+// inside the loop body), while the non-i32/i64 integer tensor iter_arg passes
+// through untouched.
+
+// Test 1: tensor<...xi8> iter_arg must NOT be wrapped.
+module {
+  tt.func public @i8_tensor_iter_arg_not_wrapped(%arg0: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    %cst_i8 = arith.constant dense<0> : tensor<4xi8>
+    %cst_one_i8 = arith.constant dense<1> : tensor<4xi8>
+    %offs = arith.constant dense<1> : tensor<4xi32>
+    %p = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %0:2 = scf.for %i = %c0 to %c4 step %c1 iter_args(%pa = %p, %ia = %cst_i8) -> (tensor<4x!tt.ptr<f32>>, tensor<4xi8>) : i32 {
+      %v = tt.load %pa : tensor<4x!tt.ptr<f32>>
+      tt.store %pa, %v : tensor<4x!tt.ptr<f32>>
+      %nextp = tt.addptr %pa, %offs : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      %nexti = arith.addi %ia, %cst_one_i8 : tensor<4xi8>
+      scf.yield %nextp, %nexti : tensor<4x!tt.ptr<f32>>, tensor<4xi8>
+    }
+    tt.return
+  }
+}
+
+// Pointer iter_arg gets wrapped twice (once before the loop, once at the yield).
+// The i8 iter_arg must not be wrapped, so the total count stays at 2.
+// CHECK-LABEL: @i8_tensor_iter_arg_not_wrapped
+// CHECK-COUNT-2: tts.get_structured_state
+// CHECK-NOT:     tts.get_structured_state
+// CHECK-NOT:     tensor<4xi8>{{.*}}tts.get_structured_state
+// CHECK-NOT:     tts.get_structured_state{{.*}}tensor<4xi8>
+
+// -----
+
+// Test 2: tensor<...xindex> iter_arg must NOT be wrapped.
+module {
+  tt.func public @index_tensor_iter_arg_not_wrapped(%arg0: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    %cst_idx = arith.constant dense<0> : tensor<4xindex>
+    %cst_one_idx = arith.constant dense<1> : tensor<4xindex>
+    %offs = arith.constant dense<1> : tensor<4xi32>
+    %p = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %0:2 = scf.for %i = %c0 to %c4 step %c1 iter_args(%pa = %p, %ia = %cst_idx) -> (tensor<4x!tt.ptr<f32>>, tensor<4xindex>) : i32 {
+      %v = tt.load %pa : tensor<4x!tt.ptr<f32>>
+      tt.store %pa, %v : tensor<4x!tt.ptr<f32>>
+      %nextp = tt.addptr %pa, %offs : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+      %nexti = arith.addi %ia, %cst_one_idx : tensor<4xindex>
+      scf.yield %nextp, %nexti : tensor<4x!tt.ptr<f32>>, tensor<4xindex>
+    }
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @index_tensor_iter_arg_not_wrapped
+// CHECK-COUNT-2: tts.get_structured_state
+// CHECK-NOT:     tts.get_structured_state
+// CHECK-NOT:     tensor<4xindex>{{.*}}tts.get_structured_state
+// CHECK-NOT:     tts.get_structured_state{{.*}}tensor<4xindex>

--- a/test/Conversion/TritonToStructured/if_2d_nested.mlir
+++ b/test/Conversion/TritonToStructured/if_2d_nested.mlir
@@ -1,0 +1,67 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_pointer_in_conditional_kernel
+// CHECK-DAG: %c0_i32 = arith.constant 0 : i32
+// CHECK-DAG: %c2_i32 = arith.constant 2 : i32
+// CHECK: %[[RESULT:.*]]:2 = scf.if %{{.*}} -> (index, !tt.ptr<f16>) {
+// CHECK: } else {
+// CHECK:   %{{.*}} = arith.select %{{.*}}, %{{.*}}, %{{.*}} : index
+// CHECK:   %{{.*}} = arith.select %{{.*}}, %arg1, %arg2 : !tt.ptr<f16>
+// CHECK: }
+// CHECK-NOT: scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK: %{{.*}} = tts.make_tptr %[[RESULT]]#1 to sizes: [16, 32], strides: [{{%c16|16}}, {{%c32|32}}], offsets: [%[[RESULT]]#0, {{%c0|0}}], shape: [0, 0], order: []
+
+module {
+  tt.func public @tensor_pointer_in_conditional_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg4: i32) attributes {noinline = false} {
+    %c2_i32 = arith.constant 2 : i32
+    %cst = arith.constant dense<10> : tensor<16x32xi32>
+    %cst_0 = arith.constant dense<32> : tensor<1x32xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %cst_1 = arith.constant dense<16> : tensor<16x1xi32>
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %2 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %3 = arith.muli %2, %cst_1 : tensor<16x1xi32>
+    %4 = tt.get_program_id x : i32
+    %5 = tt.splat %4 : i32 -> tensor<16x1xi32>
+    %6 = arith.addi %3, %5 : tensor<16x1xi32>
+    %7 = arith.cmpi ne, %arg4, %c0_i32 : i32
+    %8 = scf.if %7 -> (tensor<16x32x!tt.ptr<f16>>) {
+      %10 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x1x!tt.ptr<f16>>
+      %11 = tt.addptr %10, %6 : tensor<16x1x!tt.ptr<f16>>, tensor<16x1xi32>
+      %12 = tt.expand_dims %1 {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+      %13 = arith.muli %12, %cst_0 : tensor<1x32xi32>
+      %14 = tt.broadcast %11 : tensor<16x1x!tt.ptr<f16>> -> tensor<16x32x!tt.ptr<f16>>
+      %15 = tt.broadcast %13 : tensor<1x32xi32> -> tensor<16x32xi32>
+      %16 = tt.addptr %14, %15 : tensor<16x32x!tt.ptr<f16>>, tensor<16x32xi32>
+      %17 = tt.addptr %16, %cst : tensor<16x32x!tt.ptr<f16>>, tensor<16x32xi32>
+      scf.yield %17 : tensor<16x32x!tt.ptr<f16>>
+    } else {
+      %10 = arith.remsi %4, %c2_i32 : i32
+      %11 = arith.cmpi eq, %10, %c0_i32 : i32
+      %12 = scf.if %11 -> (tensor<16x32x!tt.ptr<f16>>) {
+        %13 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x1x!tt.ptr<f16>>
+        %14 = tt.addptr %13, %6 : tensor<16x1x!tt.ptr<f16>>, tensor<16x1xi32>
+        %15 = tt.expand_dims %1 {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+        %16 = arith.muli %15, %cst_0 : tensor<1x32xi32>
+        %17 = tt.broadcast %14 : tensor<16x1x!tt.ptr<f16>> -> tensor<16x32x!tt.ptr<f16>>
+        %18 = tt.broadcast %16 : tensor<1x32xi32> -> tensor<16x32xi32>
+        %19 = tt.addptr %17, %18 : tensor<16x32x!tt.ptr<f16>>, tensor<16x32xi32>
+        scf.yield %19 : tensor<16x32x!tt.ptr<f16>>
+      } else {
+        %13 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x1x!tt.ptr<f16>>
+        %14 = tt.addptr %13, %6 : tensor<16x1x!tt.ptr<f16>>, tensor<16x1xi32>
+        %15 = tt.expand_dims %1 {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+        %16 = arith.muli %15, %cst_0 : tensor<1x32xi32>
+        %17 = tt.broadcast %14 : tensor<16x1x!tt.ptr<f16>> -> tensor<16x32x!tt.ptr<f16>>
+        %18 = tt.broadcast %16 : tensor<1x32xi32> -> tensor<16x32xi32>
+        %19 = tt.addptr %17, %18 : tensor<16x32x!tt.ptr<f16>>, tensor<16x32xi32>
+        scf.yield %19 : tensor<16x32x!tt.ptr<f16>>
+      }
+      scf.yield %12 : tensor<16x32x!tt.ptr<f16>>
+    }
+    %9 = tt.load %8 : tensor<16x32x!tt.ptr<f16>>
+    tt.store %8, %9 : tensor<16x32x!tt.ptr<f16>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_diff_store_load_at_every_level.mlir
+++ b/test/Conversion/TritonToStructured/if_diff_store_load_at_every_level.mlir
@@ -1,0 +1,124 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_pointer_in_conditional_kernel
+// CHECK-DAG: %c5 = arith.constant 5 : index
+// CHECK-DAG: %c3 = arith.constant 3 : index
+// CHECK-DAG: %c1 = arith.constant 1 : index
+// CHECK-DAG: %c10_i32 = arith.constant 10 : i32
+// CHECK-DAG: %c2_i32 = arith.constant 2 : i32
+// CHECK-DAG: %c1_i32 = arith.constant 1 : i32
+// CHECK-DAG: %c0_i32 = arith.constant 0 : i32
+// CHECK: %[[CMP0:.*]] = arith.cmpi ne, %arg3, %c0_i32 : i32
+// CHECK: %[[SEL:.*]] = arith.select %[[CMP0]], %arg0, %arg1 : !tt.ptr<f16>
+// CHECK: %[[IF0:.*]] = scf.if %[[CMP0]] -> (index) {
+// CHECK:   %[[PID:.*]] = tt.get_program_id x : i32
+// CHECK:   %[[IDX:.*]] = arith.index_cast %[[PID]] : i32 to index
+// CHECK:   tts.make_tptr %arg0 to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[IDX]]], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:   tts.make_tptr %arg2 to sizes: [16], strides: [{{%c1|1}}], offsets: [{{%c0|0}}], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:   %[[ADD1:.*]] = arith.addi %[[IDX]], %c1 : index
+// CHECK:   %[[REM2:.*]] = arith.remsi %[[PID]], %c2_i32 : i32
+// CHECK:   %[[CMP2:.*]] = arith.cmpi eq, %[[REM2]], %c0_i32 : i32
+// CHECK:   %[[IF1:.*]] = scf.if %[[CMP2]] -> (index) {
+// CHECK:     %[[ADD3:.*]] = arith.addi %[[IDX]], %c3 : index
+// CHECK:     tts.make_tptr %arg0 to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[ADD3]]], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:     %[[REM10:.*]] = arith.remsi %[[PID]], %c10_i32 : i32
+// CHECK:     %[[CMP10:.*]] = arith.cmpi eq, %[[REM10]], %c1_i32 : i32
+// CHECK:     %[[IF2:.*]] = scf.if %[[CMP10]] -> (index) {
+// CHECK:       %[[ADD5:.*]] = arith.addi %[[IDX]], %c5 : index
+// CHECK:       tts.make_tptr %arg0 to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[ADD5]]], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:       scf.yield %[[ADD5]] : index
+// CHECK:     } else {
+// CHECK:       scf.yield %[[ADD3]] : index
+// CHECK:     }
+// CHECK:     scf.yield %[[IF2]] : index
+// CHECK:   } else {
+// CHECK:     scf.yield %[[ADD1]] : index
+// CHECK:   }
+// CHECK:   %[[FINAL:.*]] = arith.addi %[[IF1]], %c1 : index
+// CHECK:   tts.make_tptr %[[SEL]] to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[FINAL]]], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:   tts.make_tptr %arg2 to sizes: [16], strides: [{{%c1|1}}], offsets: [{{%c0|0}}], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:   scf.yield %[[FINAL]] : index
+// CHECK: } else {
+// CHECK:   %[[PID:.*]] = tt.get_program_id x : i32
+// CHECK:   %[[IDX:.*]] = arith.index_cast %[[PID]] : i32 to index
+// CHECK:   tts.make_tptr %arg1 to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[IDX]]], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:   tts.make_tptr %arg2 to sizes: [16], strides: [{{%c1|1}}], offsets: [{{%c0|0}}], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK:   scf.yield %[[IDX]] : index
+// CHECK: }
+// CHECK-NOT: scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK: tts.make_tptr %[[SEL]] to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[IF0]]], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK: tts.make_tptr %arg2 to sizes: [16], strides: [{{%c1|1}}], offsets: [{{%c0|0}}], {{.*}} : <f16> to tensor<16x!tt.ptr<f16>>
+// CHECK: tt.return
+
+module {
+  tt.func public @tensor_pointer_in_conditional_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<5> : tensor<16xi32>
+    %cst_0 = arith.constant dense<3> : tensor<16xi32>
+    %c10_i32 = arith.constant 10 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst_1 = arith.constant dense<1> : tensor<16xi32>
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.cmpi ne, %arg3, %c0_i32 : i32
+    %2 = scf.if %1 -> (tensor<16x!tt.ptr<f16>>) {
+      %7 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %8 = tt.addptr %7, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %9 = tt.get_program_id x : i32
+      %10 = tt.splat %9 : i32 -> tensor<16xi32>
+      %11 = tt.addptr %8, %10 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %12 = tt.load %11 : tensor<16x!tt.ptr<f16>>
+      %13 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %14 = tt.addptr %13, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      tt.store %14, %12 : tensor<16x!tt.ptr<f16>>
+      %15 = tt.addptr %11, %cst_1 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %16 = arith.remsi %9, %c2_i32 : i32
+      %17 = arith.cmpi eq, %16, %c0_i32 : i32
+      %18 = scf.if %17 -> (tensor<16x!tt.ptr<f16>>) {
+        %19 = tt.addptr %11, %cst_0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+        %20 = tt.load %19 : tensor<16x!tt.ptr<f16>>
+        tt.store %14, %20 : tensor<16x!tt.ptr<f16>>
+        %21 = arith.remsi %9, %c10_i32 : i32
+        %22 = arith.cmpi eq, %21, %c1_i32 : i32
+        %23 = scf.if %22 -> (tensor<16x!tt.ptr<f16>>) {
+          %24 = tt.addptr %11, %cst : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+          %25 = tt.load %24 : tensor<16x!tt.ptr<f16>>
+          tt.store %14, %25 : tensor<16x!tt.ptr<f16>>
+          scf.yield %24 : tensor<16x!tt.ptr<f16>>
+        } else {
+          scf.yield %19 : tensor<16x!tt.ptr<f16>>
+        }
+        scf.yield %23 : tensor<16x!tt.ptr<f16>>
+      } else {
+        scf.yield %15 : tensor<16x!tt.ptr<f16>>
+      }
+      scf.yield %18 : tensor<16x!tt.ptr<f16>>
+    } else {
+      %7 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %8 = tt.addptr %7, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %9 = tt.get_program_id x : i32
+      %10 = tt.splat %9 : i32 -> tensor<16xi32>
+      %11 = tt.addptr %8, %10 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %12 = tt.load %11 : tensor<16x!tt.ptr<f16>>
+      %13 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %14 = tt.addptr %13, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      tt.store %14, %12 : tensor<16x!tt.ptr<f16>>
+      scf.yield %11 : tensor<16x!tt.ptr<f16>>
+    }
+    %3 = scf.if %1 -> (tensor<16x!tt.ptr<f16>>) {
+      %7 = tt.addptr %2, %cst_1 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %8 = tt.load %7 : tensor<16x!tt.ptr<f16>>
+      %9 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %10 = tt.addptr %9, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      tt.store %10, %8 : tensor<16x!tt.ptr<f16>>
+      scf.yield %7 : tensor<16x!tt.ptr<f16>>
+    } else {
+      scf.yield %2 : tensor<16x!tt.ptr<f16>>
+    }
+    %4 = tt.load %3 : tensor<16x!tt.ptr<f16>>
+    %5 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %6 = tt.addptr %5, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    tt.store %6, %4 : tensor<16x!tt.ptr<f16>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_followed_by_if.mlir
+++ b/test/Conversion/TritonToStructured/if_followed_by_if.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_pointer_in_conditional_kernel
+// CHECK: %[[V0:.*]] = scf.if{{.*}}-> (index) {
+// CHECK: scf.yield{{.*}}: index
+// CHECK: } else {
+// CHECK: scf.yield{{.*}}: index
+// CHECK: }
+// CHECK-NOT: scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK: tts.make_tptr %arg0 to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[V0]]]
+
+module {
+  tt.func public @tensor_pointer_in_conditional_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<3> : tensor<16xi32>
+    %c2_i32 = arith.constant 2 : i32
+    %cst_0 = arith.constant dense<1> : tensor<16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    %3 = tt.get_program_id x : i32
+    %4 = tt.splat %3 : i32 -> tensor<16xi32>
+    %5 = tt.addptr %2, %4 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    %6 = arith.cmpi ne, %arg3, %c0_i32 : i32
+    %7 = scf.if %6 -> (tensor<16x!tt.ptr<f16>>) {
+      %12 = tt.addptr %5, %cst_0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %13 = arith.remsi %3, %c2_i32 : i32
+      %14 = arith.cmpi eq, %13, %c0_i32 : i32
+      %15 = scf.if %14 -> (tensor<16x!tt.ptr<f16>>) {
+        %16 = tt.addptr %5, %cst : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+        scf.yield %16 : tensor<16x!tt.ptr<f16>>
+      } else {
+        scf.yield %12 : tensor<16x!tt.ptr<f16>>
+      }
+      scf.yield %15 : tensor<16x!tt.ptr<f16>>
+    } else {
+      scf.yield %5 : tensor<16x!tt.ptr<f16>>
+    }
+    %8 = scf.if %6 -> (tensor<16x!tt.ptr<f16>>) {
+      %12 = tt.addptr %7, %cst_0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      scf.yield %12 : tensor<16x!tt.ptr<f16>>
+    } else {
+      scf.yield %7 : tensor<16x!tt.ptr<f16>>
+    }
+    %9 = tt.load %8 : tensor<16x!tt.ptr<f16>>
+    %10 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %11 = tt.addptr %10, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    tt.store %11, %9 : tensor<16x!tt.ptr<f16>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_inside_loop.mlir
+++ b/test/Conversion/TritonToStructured/if_inside_loop.mlir
@@ -1,0 +1,49 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_offset_in_conditional_kernel
+// CHECK-DAG:     %[[C16:.*]] = arith.constant 16 : index
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C0_I32:.*]] = arith.constant 0 : i32
+// CHECK-DAG:     %[[C16_I32:.*]] = arith.constant 16 : i32
+// CHECK-DAG:     %[[C1_I32:.*]] = arith.constant 1 : i32
+// CHECK:         %{{.*}}:2 = scf.for %{{.*}} = %[[C0_I32]] to %[[C16_I32]] step %[[C1_I32]] iter_args(%[[ITER_ARG5:.*]] = %[[C0]], %[[ITER_ARG6:.*]] = %[[C0]]) -> (index, index) : i32 {
+// CHECK:           %[[STORE_PTR:.*]] = tts.make_tptr %{{.*}} to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[ITER_ARG5]]], shape: [0], order: [] : <f32> to tensor<16x!tt.ptr<f32>>
+// CHECK:           %[[CMP:.*]] = arith.cmpi ne, %{{.*}}, %[[C0_I32]] : i32
+// CHECK:           %[[SEL:.*]] = arith.select %[[CMP]], %{{.*}}, %{{.*}} : !tt.ptr<f32>
+// CHECK-NOT:       scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK:           %[[LOAD_PTR:.*]] = tts.make_tptr %[[SEL]] to sizes: [16], strides: [{{%c1|1}}], offsets: [{{%c0|0}}], shape: [0], order: [] : <f32> to tensor<16x!tt.ptr<f32>>
+// CHECK:           %[[LOAD:.*]] = "tts.load"(%[[LOAD_PTR]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<16x!tt.ptr<f32>>) -> tensor<16xf32>
+// CHECK:           "tts.store"(%[[STORE_PTR]], %[[LOAD]]) <{static_mask_dims = array<i64>}> : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) -> ()
+// CHECK:           %[[NEXT_OFFSET:.*]] = arith.addi %[[ITER_ARG6]], %[[C16]] : index
+// CHECK:           scf.yield %[[ITER_ARG6]], %[[NEXT_OFFSET]] : index, index
+// CHECK:         }
+// CHECK:         tt.return
+
+module {
+  tt.func public @tensor_offset_in_conditional_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<16> : tensor<16xi32>
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %3:2 = scf.for %arg4 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg5 = %2, %arg6 = %2) -> (tensor<16x!tt.ptr<f32>>, tensor<16x!tt.ptr<f32>>) : i32 {
+      %4 = arith.cmpi ne, %arg2, %c0_i32 : i32
+      %5 = scf.if %4 -> (tensor<16x!tt.ptr<f32>>) {
+        %8 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+        %9 = tt.addptr %8, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %9 : tensor<16x!tt.ptr<f32>>
+      } else {
+        %8 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+        %9 = tt.addptr %8, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %9 : tensor<16x!tt.ptr<f32>>
+      }
+      %6 = tt.load %5 : tensor<16x!tt.ptr<f32>>
+      tt.store %arg5, %6 : tensor<16x!tt.ptr<f32>>
+      %7 = tt.addptr %arg6, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %arg6, %7 : tensor<16x!tt.ptr<f32>>, tensor<16x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_int_to_ptr.mlir
+++ b/test/Conversion/TritonToStructured/if_int_to_ptr.mlir
@@ -1,0 +1,178 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_pointer_in_conditional_kernel
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[V0:.*]]:2 = scf.if{{.*}}-> (index, !tt.ptr<f16>) {
+// CHECK: scf.yield{{.*}}: index, !tt.ptr<f16>
+// CHECK: } else {
+// CHECK: scf.yield{{.*}}: index, !tt.ptr<f16>
+// CHECK: }
+// CHECK-NOT: scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK: tts.make_tptr %[[TPTR_IF:.*]]#1 to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[TPTR_IF]]#0]
+
+module {
+  tt.func public @tensor_pointer_in_conditional_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg4: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<5> : tensor<16xi32>
+    %cst_0 = arith.constant dense<3> : tensor<16xi32>
+    %c5_i32 = arith.constant 5 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c10_i32 = arith.constant 10 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst_1 = arith.constant dense<1> : tensor<16xi32>
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.cmpi ne, %arg4, %c0_i32 : i32
+    %2 = scf.if %1 -> (tensor<16x!tt.ptr<f16>>) {
+      %7 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %8 = tt.addptr %7, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %9 = tt.get_program_id x : i32
+      %10 = tt.splat %9 : i32 -> tensor<16xi32>
+      %11 = tt.addptr %8, %10 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %12 = tt.load %11 : tensor<16x!tt.ptr<f16>>
+      %13 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %14 = tt.addptr %13, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      tt.store %14, %12 : tensor<16x!tt.ptr<f16>>
+      %15 = tt.addptr %11, %cst_1 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %16 = arith.remsi %9, %c2_i32 : i32
+      %17 = arith.cmpi eq, %16, %c0_i32 : i32
+      %18 = scf.if %17 -> (tensor<16x!tt.ptr<f16>>) {
+        %19 = tt.addptr %11, %cst_0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+        %20 = tt.load %19 : tensor<16x!tt.ptr<f16>>
+        tt.store %14, %20 : tensor<16x!tt.ptr<f16>>
+        %21 = arith.remsi %9, %c10_i32 : i32
+        %22 = arith.cmpi eq, %21, %c1_i32 : i32
+        %23 = scf.if %22 -> (tensor<16x!tt.ptr<f16>>) {
+          %24 = tt.addptr %11, %cst : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+          %25 = tt.load %24 : tensor<16x!tt.ptr<f16>>
+          tt.store %14, %25 : tensor<16x!tt.ptr<f16>>
+          scf.yield %24 : tensor<16x!tt.ptr<f16>>
+        } else {
+          scf.yield %19 : tensor<16x!tt.ptr<f16>>
+        }
+        scf.yield %23 : tensor<16x!tt.ptr<f16>>
+      } else {
+        scf.yield %15 : tensor<16x!tt.ptr<f16>>
+      }
+      scf.yield %18 : tensor<16x!tt.ptr<f16>>
+    } else {
+      %7 = tt.get_program_id x : i32
+      %8 = arith.remsi %7, %c2_i32 : i32
+      %9 = arith.cmpi eq, %8, %c0_i32 : i32
+      %10 = scf.if %9 -> (tensor<16x!tt.ptr<f16>>) {
+        %11 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+        %12 = tt.addptr %11, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+        %13 = tt.splat %7 : i32 -> tensor<16xi32>
+        %14 = tt.addptr %12, %13 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+        %15 = tt.load %14 : tensor<16x!tt.ptr<f16>>
+        %16 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+        %17 = tt.addptr %16, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+        tt.store %17, %15 : tensor<16x!tt.ptr<f16>>
+        scf.yield %14 : tensor<16x!tt.ptr<f16>>
+      } else {
+        %11 = arith.remsi %7, %c3_i32 : i32
+        %12 = arith.cmpi eq, %11, %c0_i32 : i32
+        %13 = scf.if %12 -> (tensor<16x!tt.ptr<f16>>) {
+          %14 = tt.load %arg0 : !tt.ptr<f16>
+          %15 = arith.extf %14 : f16 to f32
+          %16 = arith.fptosi %15 : f32 to i64
+          %17 = tt.int_to_ptr %16 : i64 -> !tt.ptr<f16>
+          %18 = tt.addptr %arg0, %c2_i32 : !tt.ptr<f16>, i32
+          %19 = tt.load %18 : !tt.ptr<f16>
+          %20 = arith.extf %19 : f16 to f32
+          %21 = arith.fptosi %20 : f32 to i64
+          %22 = tt.int_to_ptr %21 : i64 -> !tt.ptr<f16>
+          %23 = tt.addptr %arg0, %c3_i32 : !tt.ptr<f16>, i32
+          %24 = tt.load %23 : !tt.ptr<f16>
+          %25 = arith.extf %24 : f16 to f32
+          %26 = arith.fptosi %25 : f32 to i64
+          %27 = tt.int_to_ptr %26 : i64 -> !tt.ptr<f16>
+          %28 = arith.remsi %7, %c4_i32 : i32
+          %29 = arith.cmpi eq, %28, %c0_i32 : i32
+          %30 = scf.if %29 -> (tensor<16x!tt.ptr<f16>>) {
+            %35 = tt.splat %17 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+            %36 = tt.addptr %35, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+            %37 = tt.splat %7 : i32 -> tensor<16xi32>
+            %38 = tt.addptr %36, %37 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+            scf.yield %38 : tensor<16x!tt.ptr<f16>>
+          } else {
+            %35 = arith.remsi %7, %c5_i32 : i32
+            %36 = arith.cmpi eq, %35, %c0_i32 : i32
+            %37 = scf.if %36 -> (tensor<16x!tt.ptr<f16>>) {
+              %38 = tt.splat %22 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+              %39 = tt.addptr %38, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+              %40 = tt.splat %7 : i32 -> tensor<16xi32>
+              %41 = tt.addptr %39, %40 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+              scf.yield %41 : tensor<16x!tt.ptr<f16>>
+            } else {
+              %38 = tt.splat %27 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+              %39 = tt.addptr %38, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+              %40 = tt.splat %7 : i32 -> tensor<16xi32>
+              %41 = tt.addptr %39, %40 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+              scf.yield %41 : tensor<16x!tt.ptr<f16>>
+            }
+            scf.yield %37 : tensor<16x!tt.ptr<f16>>
+          }
+          %31 = scf.if %29 -> (tensor<16x!tt.ptr<f16>>) {
+            %35 = tt.splat %7 : i32 -> tensor<16xi32>
+            %36 = tt.addptr %30, %35 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+            scf.yield %36 : tensor<16x!tt.ptr<f16>>
+          } else {
+            %35 = arith.remsi %7, %c5_i32 : i32
+            %36 = arith.cmpi eq, %35, %c0_i32 : i32
+            %37 = scf.if %36 -> (tensor<16x!tt.ptr<f16>>) {
+              %38 = tt.get_program_id y : i32
+              %39 = tt.splat %38 : i32 -> tensor<16xi32>
+              %40 = tt.addptr %30, %39 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+              scf.yield %40 : tensor<16x!tt.ptr<f16>>
+            } else {
+              %38 = tt.get_program_id z : i32
+              %39 = tt.splat %38 : i32 -> tensor<16xi32>
+              %40 = tt.addptr %30, %39 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+              scf.yield %40 : tensor<16x!tt.ptr<f16>>
+            }
+            scf.yield %37 : tensor<16x!tt.ptr<f16>>
+          }
+          %32 = tt.load %31 : tensor<16x!tt.ptr<f16>>
+          %33 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+          %34 = tt.addptr %33, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+          tt.store %34, %32 : tensor<16x!tt.ptr<f16>>
+          scf.yield %31 : tensor<16x!tt.ptr<f16>>
+        } else {
+          %14 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+          %15 = tt.addptr %14, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+          scf.for %arg5 = %c0_i32 to %7 step %c1_i32  : i32 {
+            %16 = tt.load %15 : tensor<16x!tt.ptr<f16>>
+            %17 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+            %18 = tt.addptr %17, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+            tt.store %18, %16 : tensor<16x!tt.ptr<f16>>
+            scf.for %arg6 = %c0_i32 to %7 step %c1_i32  : i32 {
+              %19 = tt.load %15 : tensor<16x!tt.ptr<f16>>
+              tt.store %18, %19 : tensor<16x!tt.ptr<f16>>
+            }
+          }
+          scf.yield %15 : tensor<16x!tt.ptr<f16>>
+        }
+        scf.yield %13 : tensor<16x!tt.ptr<f16>>
+      }
+      scf.yield %10 : tensor<16x!tt.ptr<f16>>
+    }
+    %3 = scf.if %1 -> (tensor<16x!tt.ptr<f16>>) {
+      %7 = tt.addptr %2, %cst_1 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      %8 = tt.load %7 : tensor<16x!tt.ptr<f16>>
+      %9 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+      %10 = tt.addptr %9, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+      tt.store %10, %8 : tensor<16x!tt.ptr<f16>>
+      scf.yield %7 : tensor<16x!tt.ptr<f16>>
+    } else {
+      scf.yield %2 : tensor<16x!tt.ptr<f16>>
+    }
+    %4 = tt.load %3 : tensor<16x!tt.ptr<f16>>
+    %5 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %6 = tt.addptr %5, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    tt.store %6, %4 : tensor<16x!tt.ptr<f16>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_into_loop.mlir
+++ b/test/Conversion/TritonToStructured/if_into_loop.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_offset_in_conditional_kernel
+// CHECK-DAG: %c0 = arith.constant 0 : index
+// CHECK-DAG: %c1_i32 = arith.constant 1 : i32
+// CHECK-DAG: %c16_i32 = arith.constant 16 : i32
+// CHECK-DAG: %c0_i32 = arith.constant 0 : i32
+// CHECK: %[[PTR:.*]] = arith.select{{.*}}: !tt.ptr<f32>
+// CHECK-NOT: scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK: scf.for{{.*}}iter_args(%[[OFFSET:.*]] = %c0) -> (index)
+// CHECK: tts.make_tptr %[[PTR]] to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[OFFSET]]]{{.*}}: <f32> to tensor<16x!tt.ptr<f32>>
+
+module {
+  tt.func public @tensor_offset_in_conditional_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %cst = arith.constant dense<1> : tensor<16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi ne, %arg2, %c0_i32 : i32
+    %1 = scf.if %0 -> (tensor<16x!tt.ptr<f32>>) {
+      %3 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+      %4 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %5 = tt.addptr %4, %3 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %5 : tensor<16x!tt.ptr<f32>>
+    } else {
+      %3 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+      %4 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %5 = tt.addptr %4, %3 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %5 : tensor<16x!tt.ptr<f32>>
+    }
+    %2 = scf.for %arg4 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg5 = %1) -> (tensor<16x!tt.ptr<f32>>)  : i32 {
+      %3 = tt.load %arg5 : tensor<16x!tt.ptr<f32>>
+      tt.store %arg5, %3 : tensor<16x!tt.ptr<f32>>
+      %4 = tt.addptr %arg5, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %4 : tensor<16x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_loop_stress_test.mlir
+++ b/test/Conversion/TritonToStructured/if_loop_stress_test.mlir
@@ -1,0 +1,212 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// This stress test verifies that the triton-to-structured pass can handle
+// complex nested control flow with loops and conditionals.
+
+// CHECK-LABEL: module {
+// CHECK:   tt.func public @if_and_loop_stress_test
+// Verify no scf.yield operations yield tensor of pointers
+// CHECK-NOT:     scf.yield {{.*}} : tensor<{{.*}}x!tt.ptr
+// CHECK-NOT: tts.get_structured_state
+// CHECK:     tt.return
+// CHECK:   }
+// CHECK: }
+
+module {
+  tt.func public @if_and_loop_stress_test(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg4: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<4> : tensor<16x16xi32>
+    %c16_i32 = arith.constant 16 : i32
+    %cst_0 = arith.constant dense<3> : tensor<16x16xi32>
+    %cst_1 = arith.constant dense<2> : tensor<16x16xi32>
+    %cst_2 = arith.constant dense<1> : tensor<16x16xi32>
+    %cst_3 = arith.constant dense<13> : tensor<16x16xi32>
+    %cst_4 = arith.constant dense<12> : tensor<16x16xi32>
+    %cst_5 = arith.constant dense<11> : tensor<16x16xi32>
+    %cst_6 = arith.constant dense<128> : tensor<1x16xi32>
+    %cst_7 = arith.constant dense<64> : tensor<1x16xi32>
+    %cst_8 = arith.constant dense<32> : tensor<1x16xi32>
+    %cst_9 = arith.constant dense<128> : tensor<16x1xi32>
+    %cst_10 = arith.constant dense<64> : tensor<16x1xi32>
+    %cst_11 = arith.constant dense<32> : tensor<16x1xi32>
+    %c12_i32 = arith.constant 12 : i32
+    %c11_i32 = arith.constant 11 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c10_i32 = arith.constant 10 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.get_program_id x : i32
+    %2 = arith.remsi %1, %c2_i32 : i32
+    %3 = arith.cmpi eq, %2, %c1_i32 : i32
+    %4 = scf.if %3 -> (!tt.ptr<f16>) {
+      %17 = tt.addptr %arg0, %c10_i32 : !tt.ptr<f16>, i32
+      scf.yield %17 : !tt.ptr<f16>
+    } else {
+      %17 = arith.cmpi eq, %2, %c0_i32 : i32
+      %18 = scf.if %17 -> (!tt.ptr<f16>) {
+        %19 = tt.addptr %arg1, %c11_i32 : !tt.ptr<f16>, i32
+        scf.yield %19 : !tt.ptr<f16>
+      } else {
+        %19 = tt.addptr %arg2, %c12_i32 : !tt.ptr<f16>, i32
+        scf.yield %19 : !tt.ptr<f16>
+      }
+      scf.yield %18 : !tt.ptr<f16>
+    }
+    %5 = arith.remsi %arg4, %c2_i32 : i32
+    %6 = arith.cmpi eq, %5, %c0_i32 : i32
+    %7 = scf.if %6 -> (tensor<16x1xi32>) {
+      %17 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+      %18 = arith.muli %17, %cst_11 : tensor<16x1xi32>
+      scf.yield %18 : tensor<16x1xi32>
+    } else {
+      %17 = arith.cmpi eq, %2, %c0_i32 : i32
+      %18 = scf.if %17 -> (tensor<16x1xi32>) {
+        %19 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+        %20 = arith.muli %19, %cst_10 : tensor<16x1xi32>
+        scf.yield %20 : tensor<16x1xi32>
+      } else {
+        %19 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+        %20 = arith.muli %19, %cst_9 : tensor<16x1xi32>
+        scf.yield %20 : tensor<16x1xi32>
+      }
+      scf.yield %18 : tensor<16x1xi32>
+    }
+    %8 = scf.if %6 -> (tensor<1x16xi32>) {
+      %17 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+      %18 = arith.muli %17, %cst_8 : tensor<1x16xi32>
+      scf.yield %18 : tensor<1x16xi32>
+    } else {
+      %17 = arith.cmpi eq, %2, %c0_i32 : i32
+      %18 = scf.if %17 -> (tensor<1x16xi32>) {
+        %19 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+        %20 = arith.muli %19, %cst_7 : tensor<1x16xi32>
+        scf.yield %20 : tensor<1x16xi32>
+      } else {
+        %19 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+        %20 = arith.muli %19, %cst_6 : tensor<1x16xi32>
+        scf.yield %20 : tensor<1x16xi32>
+      }
+      scf.yield %18 : tensor<1x16xi32>
+    }
+    %9 = scf.if %6 -> (tensor<16x16x!tt.ptr<f16>>) {
+      %17 = tt.splat %4 : !tt.ptr<f16> -> tensor<16x1x!tt.ptr<f16>>
+      %18 = tt.addptr %17, %7 : tensor<16x1x!tt.ptr<f16>>, tensor<16x1xi32>
+      %19 = tt.broadcast %18 : tensor<16x1x!tt.ptr<f16>> -> tensor<16x16x!tt.ptr<f16>>
+      %20 = tt.broadcast %8 : tensor<1x16xi32> -> tensor<16x16xi32>
+      %21 = tt.addptr %19, %20 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+      %22 = tt.addptr %21, %cst_5 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+      scf.yield %22 : tensor<16x16x!tt.ptr<f16>>
+    } else {
+      %17 = arith.cmpi eq, %2, %c0_i32 : i32
+      %18 = scf.if %17 -> (tensor<16x16x!tt.ptr<f16>>) {
+        %19 = tt.splat %4 : !tt.ptr<f16> -> tensor<16x1x!tt.ptr<f16>>
+        %20 = tt.addptr %19, %7 : tensor<16x1x!tt.ptr<f16>>, tensor<16x1xi32>
+        %21 = tt.broadcast %20 : tensor<16x1x!tt.ptr<f16>> -> tensor<16x16x!tt.ptr<f16>>
+        %22 = tt.broadcast %8 : tensor<1x16xi32> -> tensor<16x16xi32>
+        %23 = tt.addptr %21, %22 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+        %24 = tt.addptr %23, %cst_4 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+        scf.yield %24 : tensor<16x16x!tt.ptr<f16>>
+      } else {
+        %19 = tt.splat %4 : !tt.ptr<f16> -> tensor<16x1x!tt.ptr<f16>>
+        %20 = tt.addptr %19, %7 : tensor<16x1x!tt.ptr<f16>>, tensor<16x1xi32>
+        %21 = tt.broadcast %20 : tensor<16x1x!tt.ptr<f16>> -> tensor<16x16x!tt.ptr<f16>>
+        %22 = tt.broadcast %8 : tensor<1x16xi32> -> tensor<16x16xi32>
+        %23 = tt.addptr %21, %22 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+        %24 = tt.addptr %23, %cst_3 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+        scf.yield %24 : tensor<16x16x!tt.ptr<f16>>
+      }
+      scf.yield %18 : tensor<16x16x!tt.ptr<f16>>
+    }
+    %10 = scf.for %arg5 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg6 = %9) -> (tensor<16x16x!tt.ptr<f16>>)  : i32 {
+      %17 = tt.load %arg6 : tensor<16x16x!tt.ptr<f16>>
+      tt.store %arg6, %17 : tensor<16x16x!tt.ptr<f16>>
+      %18 = tt.splat %arg5 : i32 -> tensor<16x16xi32>
+      %19 = tt.addptr %arg6, %18 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+      %20 = scf.for %arg7 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg8 = %19) -> (tensor<16x16x!tt.ptr<f16>>)  : i32 {
+        %21 = tt.load %arg8 : tensor<16x16x!tt.ptr<f16>>
+        tt.store %arg8, %21 : tensor<16x16x!tt.ptr<f16>>
+        %22 = tt.splat %arg7 : i32 -> tensor<16x16xi32>
+        %23 = tt.addptr %arg8, %22 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+        %24 = arith.remsi %arg7, %c2_i32 : i32
+        %25 = arith.cmpi eq, %24, %c0_i32 : i32
+        %26 = scf.if %25 -> (tensor<16x16x!tt.ptr<f16>>) {
+          %28 = arith.remsi %arg5, %c2_i32 : i32
+          %29 = arith.cmpi eq, %28, %c1_i32 : i32
+          %30 = scf.if %29 -> (tensor<16x16x!tt.ptr<f16>>) {
+            %31 = tt.addptr %23, %cst_0 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+            scf.yield %31 : tensor<16x16x!tt.ptr<f16>>
+          } else {
+            %31 = scf.if %25 -> (tensor<16x16x!tt.ptr<f16>>) {
+              %32 = tt.addptr %23, %cst_1 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+              scf.yield %32 : tensor<16x16x!tt.ptr<f16>>
+            } else {
+              %32 = tt.addptr %23, %cst : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+              scf.yield %32 : tensor<16x16x!tt.ptr<f16>>
+            }
+            scf.yield %31 : tensor<16x16x!tt.ptr<f16>>
+          }
+          scf.yield %30 : tensor<16x16x!tt.ptr<f16>>
+        } else {
+          scf.yield %23 : tensor<16x16x!tt.ptr<f16>>
+        }
+        %27 = scf.for %arg9 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg10 = %26) -> (tensor<16x16x!tt.ptr<f16>>)  : i32 {
+          %28 = tt.load %arg10 : tensor<16x16x!tt.ptr<f16>>
+          tt.store %arg10, %28 : tensor<16x16x!tt.ptr<f16>>
+          %29 = tt.splat %arg9 : i32 -> tensor<16x16xi32>
+          %30 = tt.addptr %arg10, %29 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+          %31 = arith.remsi %arg9, %c2_i32 : i32
+          %32 = arith.cmpi eq, %31, %c0_i32 : i32
+          %33 = scf.if %32 -> (tensor<16x16x!tt.ptr<f16>>) {
+            %34 = arith.remsi %arg5, %c2_i32 : i32
+            %35 = arith.cmpi eq, %34, %c1_i32 : i32
+            %36 = scf.if %35 -> (tensor<16x16x!tt.ptr<f16>>) {
+              %37 = tt.addptr %30, %cst_0 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+              scf.yield %37 : tensor<16x16x!tt.ptr<f16>>
+            } else {
+              %37 = scf.if %25 -> (tensor<16x16x!tt.ptr<f16>>) {
+                %38 = tt.addptr %30, %cst_1 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+                scf.yield %38 : tensor<16x16x!tt.ptr<f16>>
+              } else {
+                %38 = tt.addptr %30, %cst : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+                scf.yield %38 : tensor<16x16x!tt.ptr<f16>>
+              }
+              scf.yield %37 : tensor<16x16x!tt.ptr<f16>>
+            }
+            scf.yield %36 : tensor<16x16x!tt.ptr<f16>>
+          } else {
+            scf.yield %30 : tensor<16x16x!tt.ptr<f16>>
+          }
+          scf.yield %33 : tensor<16x16x!tt.ptr<f16>>
+        }
+        scf.yield %27 : tensor<16x16x!tt.ptr<f16>>
+      }
+      scf.yield %20 : tensor<16x16x!tt.ptr<f16>>
+    }
+    %11 = arith.cmpi eq, %2, %c0_i32 : i32
+    %12 = scf.if %11 -> (tensor<16x16x!tt.ptr<f16>>) {
+      %17 = tt.addptr %10, %cst_2 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+      scf.yield %17 : tensor<16x16x!tt.ptr<f16>>
+    } else {
+      scf.yield %10 : tensor<16x16x!tt.ptr<f16>>
+    }
+    %13 = arith.remsi %2, %c2_i32 : i32
+    %14 = arith.cmpi eq, %13, %c1_i32 : i32
+    %15 = scf.if %14 -> (tensor<16x16x!tt.ptr<f16>>) {
+      %17 = tt.addptr %12, %cst_1 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+      scf.yield %17 : tensor<16x16x!tt.ptr<f16>>
+    } else {
+      %17 = arith.cmpi eq, %13, %c0_i32 : i32
+      %18 = scf.if %17 -> (tensor<16x16x!tt.ptr<f16>>) {
+        %19 = tt.addptr %12, %cst_2 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+        scf.yield %19 : tensor<16x16x!tt.ptr<f16>>
+      } else {
+        %19 = tt.addptr %12, %cst_0 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi32>
+        scf.yield %19 : tensor<16x16x!tt.ptr<f16>>
+      }
+      scf.yield %18 : tensor<16x16x!tt.ptr<f16>>
+    }
+    %16 = tt.load %15 : tensor<16x16x!tt.ptr<f16>>
+    tt.store %15, %16 : tensor<16x16x!tt.ptr<f16>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_modulo_mixed.mlir
+++ b/test/Conversion/TritonToStructured/if_modulo_mixed.mlir
@@ -1,0 +1,105 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// Test that pointer state with modulo inside scf.if is skipped.
+
+module {
+  tt.func @kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %cond: i1) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c10 = arith.constant 10 : index
+    %c16 = arith.constant 16 : i32
+    %c256 = arith.constant 256 : i32
+
+    %range = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %splat_c16 = tt.splat %c16 : i32 -> tensor<256xi32>
+    %splat_c256 = tt.splat %c256 : i32 -> tensor<256xi32>
+
+    %if_result:2 = scf.if %cond -> (tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>) {
+      %splat_structured = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+      %ptr_structured = tt.addptr %splat_structured, %range : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+
+      %splat_unstructured = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+      %mod_range = arith.remsi %range, %splat_c16 : tensor<256xi32>
+      %ptr_unstructured = tt.addptr %splat_unstructured, %mod_range : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+
+      scf.yield %ptr_structured, %ptr_unstructured : tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+    } else {
+      %splat_structured = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+      %offset = arith.addi %range, %splat_c256 : tensor<256xi32>
+      %ptr_structured = tt.addptr %splat_structured, %offset : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+
+      %splat_unstructured = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+      %mod_range = arith.remsi %range, %splat_c16 : tensor<256xi32>
+      %ptr_unstructured = tt.addptr %splat_unstructured, %mod_range : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+
+      scf.yield %ptr_structured, %ptr_unstructured : tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+    }
+
+    %output_ptr = tt.splat %arg2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %output_offset = arith.muli %range, %splat_c16 : tensor<256xi32>
+    %output = tt.addptr %output_ptr, %output_offset : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+
+    %loop_result:2 = scf.for %i = %c0 to %c10 step %c1
+      iter_args(%ptr_structured_iter = %if_result#0, %ptr_unstructured_iter = %if_result#1)
+      -> (tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>) {
+
+      // Load from both pointers
+      %data1 = tt.load %ptr_structured_iter : tensor<256x!tt.ptr<f32>>
+      %data2 = tt.load %ptr_unstructured_iter : tensor<256x!tt.ptr<f32>>
+
+      // Store to prevent elimination
+      %sum = arith.addf %data1, %data2 : tensor<256xf32>
+      tt.store %output, %sum : tensor<256x!tt.ptr<f32>>
+
+      %c256_offset = tt.splat %c256 : i32 -> tensor<256xi32>
+      %ptr_structured_next = tt.addptr %ptr_structured_iter, %c256_offset : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+
+      %c16_offset = tt.splat %c16 : i32 -> tensor<256xi32>
+      %ptr_unstructured_next = tt.addptr %ptr_unstructured_iter, %c16_offset : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+
+      scf.yield %ptr_structured_next, %ptr_unstructured_next : tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+    }
+
+    %final_data1 = tt.load %loop_result#0 : tensor<256x!tt.ptr<f32>>
+    %final_data2 = tt.load %loop_result#1 : tensor<256x!tt.ptr<f32>>
+    %final_sum = arith.addf %final_data1, %final_data2 : tensor<256xf32>
+    tt.store %output, %final_sum : tensor<256x!tt.ptr<f32>>
+
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @kernel
+// CHECK-DAG: %[[CST_256:.*]] = arith.constant dense<256> : tensor<256xi32>
+// CHECK-DAG: %[[CST_16:.*]] = arith.constant dense<16> : tensor<256xi32>
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C10:.*]] = arith.constant 10 : index
+// CHECK: %[[RANGE:.*]] = tt.make_range
+
+// Verify the scf.if exists and returns two pointers (both as tensor<256x!tt.ptr<f32>>)
+// CHECK: %[[IF_RESULT:.*]]:2 = scf.if
+// CHECK: scf.yield {{.*}}, {{.*}} : tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+// CHECK: } else {
+// CHECK: scf.yield {{.*}}, {{.*}} : tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+// CHECK: }
+
+// CHECK-NOT: tts.make_tptr %{{.*}} to sizes: [256], strides: [%{{.*}}], offsets: [%[[IF_RESULT]]
+
+// CHECK: %[[OUTPUT_PTR:.*]] = tts.make_tptr {{.*}} to sizes: [256], strides: [{{%c16|16}}], offsets: [{{%c0|0}}]
+
+// CHECK: %[[LOOP_RESULT:.*]]:2 = scf.for {{.*}} iter_args(%[[ARG5:.*]] = %[[IF_RESULT]]#0, %[[ARG6:.*]] = %[[IF_RESULT]]#1)
+
+// CHECK: tt.load %[[ARG5]] : tensor<256x!tt.ptr<f32>>
+// CHECK: tt.load %[[ARG6]] : tensor<256x!tt.ptr<f32>>
+
+// CHECK: "tts.store"(%[[OUTPUT_PTR]],
+
+// CHECK: tt.addptr %[[ARG5]], %[[CST_256]]
+// CHECK: tt.addptr %[[ARG6]], %[[CST_16]]
+// CHECK: scf.yield {{.*}}, {{.*}} : tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+
+// CHECK: tt.load %[[LOOP_RESULT]]#0 : tensor<256x!tt.ptr<f32>>
+// CHECK: tt.load %[[LOOP_RESULT]]#1 : tensor<256x!tt.ptr<f32>>
+// CHECK: "tts.store"
+// CHECK: tt.return

--- a/test/Conversion/TritonToStructured/if_multiple_ptrs.mlir
+++ b/test/Conversion/TritonToStructured/if_multiple_ptrs.mlir
@@ -1,0 +1,124 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// IR of the following program:
+// @triton.jit
+// def multiple_ptrs(
+//     x_ptr,
+//     y_ptr,
+//     z_ptr,
+//     x_out_ptr,
+//     y_out_ptr,
+//     z_out_ptr,
+//     stride_row,
+//     stride_col,
+//     x_row_offset,
+//     y_row_offset,
+//     z_row_offset,
+//     x_col_offset,
+//     y_col_offset,
+//     z_col_offset,
+//     use_x,
+//     use_y,
+//     use_z,
+//     BLOCK_SIZE_ROW: tl.constexpr,
+//     BLOCK_SIZE_COL: tl.constexpr,
+// ):
+//     row_offsets = tl.arange(0, BLOCK_SIZE_ROW)[:, None]
+//     col_offsets = tl.arange(0, BLOCK_SIZE_COL)[None, :]
+//     out_offsets = row_offsets * stride_row + col_offsets * stride_col
+//     if use_x:
+//         offsets = (
+//             x_row_offset
+//             + row_offsets * stride_row
+//             + x_col_offset
+//             + col_offsets * stride_col
+//         )
+//         # in_ptrs is unstructured in one branch, this should make all other branches unstructured
+//         in_ptrs = x_ptr + offsets // 2
+//         out_ptrs = x_out_ptr + out_offsets
+//     elif use_y:
+//         offsets = (
+//             y_row_offset
+//             + row_offsets * stride_row
+//             + y_col_offset
+//             + col_offsets * stride_col
+//         )
+//         in_ptrs = y_ptr + offsets
+//         out_ptrs = y_out_ptr + out_offsets
+//     else:
+//         offsets = (
+//             z_row_offset
+//             + row_offsets * stride_row
+//             + z_col_offset
+//             + col_offsets * stride_col
+//         )
+//         in_ptrs = z_ptr + offsets
+//         out_ptrs = z_out_ptr + out_offsets
+//
+//     vals = tl.load(in_ptrs)
+//     tl.store(out_ptrs, vals)
+//
+// We have one branch that is unstructured, currently we bail out entirely.
+
+// CHECK-NOT: tts
+
+module {
+  tt.func public @multiple_ptrs(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<2> : tensor<16x16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %2 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %3 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+    %4 = arith.muli %1, %3 : tensor<16x1xi32>
+    %5 = tt.broadcast %4 : tensor<16x1xi32> -> tensor<16x16xi32>
+    %6 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+    %7 = arith.addi %5, %6 : tensor<16x16xi32>
+    %8 = arith.cmpi ne, %arg13, %c0_i32 : i32
+    %9:2 = scf.if %8 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+      %11 = tt.splat %arg7 : i32 -> tensor<16x1xi32>
+      %12 = arith.addi %11, %4 : tensor<16x1xi32>
+      %13 = tt.splat %arg10 : i32 -> tensor<16x1xi32>
+      %14 = arith.addi %12, %13 : tensor<16x1xi32>
+      %15 = tt.broadcast %14 : tensor<16x1xi32> -> tensor<16x16xi32>
+      %16 = arith.addi %15, %6 : tensor<16x16xi32>
+      %17 = arith.divsi %16, %cst : tensor<16x16xi32>
+      %18 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %19 = tt.addptr %18, %17 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      %20 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %21 = tt.addptr %20, %7 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      scf.yield %19, %21 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>> // unstructured, structured
+    } else {
+      %11 = arith.cmpi ne, %arg14, %c0_i32 : i32
+      %12:2 = scf.if %11 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+        %13 = tt.splat %arg8 : i32 -> tensor<16x1xi32>
+        %14 = arith.addi %13, %4 : tensor<16x1xi32>
+        %15 = tt.splat %arg11 : i32 -> tensor<16x1xi32>
+        %16 = arith.addi %14, %15 : tensor<16x1xi32>
+        %17 = tt.broadcast %16 : tensor<16x1xi32> -> tensor<16x16xi32>
+        %18 = arith.addi %17, %6 : tensor<16x16xi32>
+        %19 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %20 = tt.addptr %19, %18 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        %21 = tt.splat %arg4 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %22 = tt.addptr %21, %7 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        scf.yield %20, %22 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+      } else {
+        %13 = tt.splat %arg9 : i32 -> tensor<16x1xi32>
+        %14 = arith.addi %13, %4 : tensor<16x1xi32>
+        %15 = tt.splat %arg12 : i32 -> tensor<16x1xi32>
+        %16 = arith.addi %14, %15 : tensor<16x1xi32>
+        %17 = tt.broadcast %16 : tensor<16x1xi32> -> tensor<16x16xi32>
+        %18 = arith.addi %17, %6 : tensor<16x16xi32>
+        %19 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %20 = tt.addptr %19, %18 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        %21 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %22 = tt.addptr %21, %7 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        scf.yield %20, %22 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+      }
+      scf.yield %12#0, %12#1 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    }
+    %10 = tt.load %9#0 : tensor<16x16x!tt.ptr<f32>>
+    tt.store %9#1, %10 : tensor<16x16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_nested.mlir
+++ b/test/Conversion/TritonToStructured/if_nested.mlir
@@ -1,0 +1,148 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @cf_nested
+// CHECK: %[[CMP:.*]] = arith.cmpi eq, %arg3
+// CHECK: %[[PTR_SELECT:.*]] = arith.select %[[CMP]], %arg0, %arg1 : !tt.ptr<f32>
+// CHECK: %[[OFFSET:.*]] = scf.if %[[CMP]] -> (index)
+// CHECK-NOT: scf.if {{.*}} -> (tensor<{{.*}}x!tt.ptr
+// CHECK: tts.make_tptr %[[PTR_SELECT]] to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[OFFSET]]]
+
+module {
+  tt.func public @cf_nested(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32, %arg4: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %cst = arith.constant dense<16> : tensor<16xi32>
+    %c16_i32 = arith.constant 16 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c11_i32 = arith.constant 11 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.cmpi eq, %arg3, %c11_i32 : i32
+    %2 = scf.if %1 -> (tensor<16x!tt.ptr<f32>>) {
+      %6 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %7 = tt.addptr %6, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %8 = arith.cmpi ne, %arg4, %c0_i32 : i32
+      %9 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+        %14 = arith.muli %arg4, %c16_i32 : i32
+        %15 = tt.splat %14 : i32 -> tensor<16xi32>
+        %16 = tt.addptr %7, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %16 : tensor<16x!tt.ptr<f32>>
+      } else {
+        scf.yield %7 : tensor<16x!tt.ptr<f32>>
+      }
+      %10 = tt.addptr %9, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %11 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+        %14 = arith.muli %arg4, %c32_i32 : i32
+        %15 = tt.splat %14 : i32 -> tensor<16xi32>
+        %16 = tt.addptr %10, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %17 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = arith.muli %arg4, %c16_i32 : i32
+          %21 = tt.splat %20 : i32 -> tensor<16xi32>
+          %22 = tt.addptr %16, %21 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %22 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %16 : tensor<16x!tt.ptr<f32>>
+        }
+        %18 = tt.addptr %17, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %19 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = tt.addptr %18, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %20 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %18 : tensor<16x!tt.ptr<f32>>
+        }
+        scf.yield %19 : tensor<16x!tt.ptr<f32>>
+      } else {
+        scf.yield %10 : tensor<16x!tt.ptr<f32>>
+      }
+      %12 = tt.addptr %11, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %13 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+        %14 = arith.muli %arg4, %c32_i32 : i32
+        %15 = tt.splat %14 : i32 -> tensor<16xi32>
+        %16 = tt.addptr %12, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %17 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = arith.muli %arg4, %c16_i32 : i32
+          %21 = tt.splat %20 : i32 -> tensor<16xi32>
+          %22 = tt.addptr %16, %21 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %22 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %16 : tensor<16x!tt.ptr<f32>>
+        }
+        %18 = tt.addptr %17, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %19 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = tt.addptr %18, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %20 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %18 : tensor<16x!tt.ptr<f32>>
+        }
+        scf.yield %19 : tensor<16x!tt.ptr<f32>>
+      } else {
+        scf.yield %12 : tensor<16x!tt.ptr<f32>>
+      }
+      scf.yield %13 : tensor<16x!tt.ptr<f32>>
+    } else {
+      %6 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %7 = tt.addptr %6, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %8 = arith.cmpi ne, %arg4, %c0_i32 : i32
+      %9 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+        %14 = arith.muli %arg4, %c16_i32 : i32
+        %15 = tt.splat %14 : i32 -> tensor<16xi32>
+        %16 = tt.addptr %7, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %16 : tensor<16x!tt.ptr<f32>>
+      } else {
+        scf.yield %7 : tensor<16x!tt.ptr<f32>>
+      }
+      %10 = tt.addptr %9, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %11 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+        %14 = arith.muli %arg4, %c32_i32 : i32
+        %15 = tt.splat %14 : i32 -> tensor<16xi32>
+        %16 = tt.addptr %10, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %17 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = arith.muli %arg4, %c16_i32 : i32
+          %21 = tt.splat %20 : i32 -> tensor<16xi32>
+          %22 = tt.addptr %16, %21 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %22 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %16 : tensor<16x!tt.ptr<f32>>
+        }
+        %18 = tt.addptr %17, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %19 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = tt.addptr %18, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %20 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %18 : tensor<16x!tt.ptr<f32>>
+        }
+        scf.yield %19 : tensor<16x!tt.ptr<f32>>
+      } else {
+        scf.yield %10 : tensor<16x!tt.ptr<f32>>
+      }
+      %12 = tt.addptr %11, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %13 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+        %14 = arith.muli %arg4, %c32_i32 : i32
+        %15 = tt.splat %14 : i32 -> tensor<16xi32>
+        %16 = tt.addptr %12, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %17 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = arith.muli %arg4, %c16_i32 : i32
+          %21 = tt.splat %20 : i32 -> tensor<16xi32>
+          %22 = tt.addptr %16, %21 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %22 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %16 : tensor<16x!tt.ptr<f32>>
+        }
+        %18 = tt.addptr %17, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        %19 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+          %20 = tt.addptr %18, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          scf.yield %20 : tensor<16x!tt.ptr<f32>>
+        } else {
+          scf.yield %18 : tensor<16x!tt.ptr<f32>>
+        }
+        scf.yield %19 : tensor<16x!tt.ptr<f32>>
+      } else {
+        scf.yield %12 : tensor<16x!tt.ptr<f32>>
+      }
+      scf.yield %13 : tensor<16x!tt.ptr<f32>>
+    }
+    %3 = tt.load %2 : tensor<16x!tt.ptr<f32>>
+    %4 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    tt.store %5, %3 : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_nested_if_wrapping_nested_loops.mlir
+++ b/test/Conversion/TritonToStructured/if_nested_if_wrapping_nested_loops.mlir
@@ -1,0 +1,93 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @tensor_offset_in_conditional_kernel
+// CHECK-NOT: tts.get_structured_state
+// Verify no scf.yield operations yield tensor of pointers
+// CHECK-NOT:     scf.yield {{.*}} : tensor<{{.*}}x!tt.ptr
+
+module {
+  tt.func public @tensor_offset_in_conditional_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<14> : tensor<16xi32>
+    %cst_0 = arith.constant dense<8> : tensor<16xi32>
+    %c1_i32 = arith.constant 1 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %cst_1 = arith.constant dense<4> : tensor<16xi32>
+    %cst_2 = arith.constant dense<3> : tensor<16xi32>
+    %c3_i32 = arith.constant 3 : i32
+    %cst_3 = arith.constant dense<2> : tensor<16xi32>
+    %c2_i32 = arith.constant 2 : i32
+    %cst_4 = arith.constant dense<1> : tensor<16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi ne, %arg2, %c0_i32 : i32
+    %1 = scf.if %0 -> (tensor<16x!tt.ptr<f32>>) {
+      %3 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+      %4 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %5 = tt.addptr %4, %3 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %5 : tensor<16x!tt.ptr<f32>>
+    } else {
+      %3 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+      %4 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %5 = tt.addptr %4, %3 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %5 : tensor<16x!tt.ptr<f32>>
+    }
+    %2 = scf.for %arg4 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg5 = %1) -> (tensor<16x!tt.ptr<f32>>)  : i32 {
+      %3 = scf.if %0 -> (tensor<16x!tt.ptr<f32>>) {
+        %8 = tt.addptr %arg5, %cst_4 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %8 : tensor<16x!tt.ptr<f32>>
+      } else {
+        %8 = tt.addptr %arg5, %cst_3 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %8 : tensor<16x!tt.ptr<f32>>
+      }
+      %4 = tt.load %3 : tensor<16x!tt.ptr<f32>>
+      tt.store %3, %4 : tensor<16x!tt.ptr<f32>>
+      %5:2 = scf.for %arg6 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg7 = %3, %arg8 = %4) -> (tensor<16x!tt.ptr<f32>>, tensor<16xf32>)  : i32 {
+        %8:2 = scf.if %0 -> (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) {
+          %9 = tt.addptr %arg7, %cst_2 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          %10 = tt.get_program_id x : i32
+          %11 = arith.remsi %10, %c2_i32 : i32
+          %12 = arith.cmpi eq, %11, %c0_i32 : i32
+          %13:2 = scf.if %12 -> (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) {
+            %14 = tt.addptr %arg7, %cst_0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+            %15 = tt.load %14 : tensor<16x!tt.ptr<f32>>
+            tt.store %14, %15 : tensor<16x!tt.ptr<f32>>
+            %16 = arith.remsi %10, %c3_i32 : i32
+            %17 = arith.cmpi eq, %16, %c0_i32 : i32
+            %18:2 = scf.if %17 -> (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) {
+              %19 = tt.addptr %arg7, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+              %20:2 = scf.for %arg9 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg10 = %15, %arg11 = %19) -> (tensor<16xf32>, tensor<16x!tt.ptr<f32>>)  : i32 {
+                %21 = tt.load %arg11 : tensor<16x!tt.ptr<f32>>
+                tt.store %arg11, %21 : tensor<16x!tt.ptr<f32>>
+                %22 = tt.addptr %arg11, %cst_4 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+                scf.yield %21, %22 : tensor<16xf32>, tensor<16x!tt.ptr<f32>>
+              }
+              scf.yield %20#1, %20#0 : tensor<16x!tt.ptr<f32>>, tensor<16xf32>
+            } else {
+              scf.yield %14, %15 : tensor<16x!tt.ptr<f32>>, tensor<16xf32>
+            }
+            scf.yield %18#0, %18#1 : tensor<16x!tt.ptr<f32>>, tensor<16xf32>
+          } else {
+            scf.yield %9, %arg8 : tensor<16x!tt.ptr<f32>>, tensor<16xf32>
+          }
+          scf.yield %13#0, %13#1 : tensor<16x!tt.ptr<f32>>, tensor<16xf32>
+        } else {
+          %9 = tt.addptr %arg7, %cst_1 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+          %10 = tt.load %9 : tensor<16x!tt.ptr<f32>>
+          tt.store %9, %10 : tensor<16x!tt.ptr<f32>>
+          scf.yield %9, %10 : tensor<16x!tt.ptr<f32>>, tensor<16xf32>
+        }
+        scf.yield %8#0, %8#1 : tensor<16x!tt.ptr<f32>>, tensor<16xf32>
+      }
+      %6 = scf.if %0 -> (tensor<16x!tt.ptr<f32>>) {
+        %8 = tt.addptr %5#0, %cst_4 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %8 : tensor<16x!tt.ptr<f32>>
+      } else {
+        %8 = tt.addptr %5#0, %cst_3 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %8 : tensor<16x!tt.ptr<f32>>
+      }
+      %7 = tt.load %6 : tensor<16x!tt.ptr<f32>>
+      tt.store %6, %7 : tensor<16x!tt.ptr<f32>>
+      scf.yield %6 : tensor<16x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_postincrement.mlir
+++ b/test/Conversion/TritonToStructured/if_postincrement.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @cf_postincrement
+// CHECK: %[[SELECT:.*]] = arith.select {{.*}} : !tt.ptr<f32>
+// CHECK: %[[IF_RESULT:.*]] = scf.if {{.*}} -> (index)
+// CHECK: tts.make_tptr %[[SELECT]] to sizes: [16], strides: [{{.*}}], offsets: [%[[IF_RESULT]]]
+
+module {
+  tt.func public @cf_postincrement(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32, %arg4: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<16> : tensor<16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %c11_i32 = arith.constant 11 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.cmpi eq, %arg3, %c11_i32 : i32
+    %2 = scf.if %1 -> (tensor<16x!tt.ptr<f32>>) {
+      %6 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %7 = tt.addptr %6, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      %8 = arith.cmpi ne, %arg4, %c0_i32 : i32
+      %9 = scf.if %8 -> (tensor<16x!tt.ptr<f32>>) {
+        %10 = tt.addptr %7, %cst : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+        scf.yield %10 : tensor<16x!tt.ptr<f32>>
+      } else {
+        scf.yield %7 : tensor<16x!tt.ptr<f32>>
+      }
+      scf.yield %9 : tensor<16x!tt.ptr<f32>>
+    } else {
+      %6 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %7 = tt.addptr %6, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %7 : tensor<16x!tt.ptr<f32>>
+    }
+    %3 = tt.load %2 : tensor<16x!tt.ptr<f32>>
+    %4 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    tt.store %5, %3 : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_preincrement.mlir
+++ b/test/Conversion/TritonToStructured/if_preincrement.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @cf_preincrement
+// CHECK: %[[SELECT:.*]] = arith.select {{.*}} : !tt.ptr<f32>
+// CHECK: %[[IF_RESULT:.*]] = scf.if {{.*}} -> (index)
+// CHECK: tts.make_tptr %[[SELECT]] to sizes: [16], strides: [{{.*}}], offsets: [%[[IF_RESULT]]]
+
+module {
+  tt.func public @cf_preincrement(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32, %arg4: i32) attributes {noinline = false} {
+    %c16_i32 = arith.constant 16 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c11_i32 = arith.constant 11 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = arith.cmpi eq, %arg3, %c11_i32 : i32
+    %2 = scf.if %1 -> (tensor<16x!tt.ptr<f32>>) {
+      %6 = arith.cmpi ne, %arg4, %c0_i32 : i32
+      %7 = scf.if %6 -> (!tt.ptr<f32>) {
+        %10 = tt.addptr %arg0, %c16_i32 : !tt.ptr<f32>, i32
+        scf.yield %10 : !tt.ptr<f32>
+      } else {
+        scf.yield %arg0 : !tt.ptr<f32>
+      }
+      %8 = tt.splat %7 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %9 = tt.addptr %8, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %9 : tensor<16x!tt.ptr<f32>>
+    } else {
+      %6 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+      %7 = tt.addptr %6, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+      scf.yield %7 : tensor<16x!tt.ptr<f32>>
+    }
+    %3 = tt.load %2 : tensor<16x!tt.ptr<f32>>
+    %4 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    tt.store %5, %3 : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_returning_mixed_both_branches_unstructured.mlir
+++ b/test/Conversion/TritonToStructured/if_returning_mixed_both_branches_unstructured.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @test_multiple_ptrs_if_kernel
+// CHECK-DAG: %cst = arith.constant dense<2> : tensor<16x16xi32>
+// CHECK-DAG: %c0_i32 = arith.constant 0 : i32
+// CHECK: %[[PTR:.*]] = arith.select{{.*}}: !tt.ptr<f32>
+// CHECK: %[[IF_RESULT:.*]]:3 = scf.if{{.*}}-> (index, index, tensor<16x16x!tt.ptr<f32>>)
+// CHECK: tts.make_tptr %[[PTR]] to sizes: [16, 16], strides: [%[[IF_RESULT]]#1, {{%c1|1}}], offsets: [%[[IF_RESULT]]#0, {{%c0|0}}]{{.*}}: <f32> to tensor<16x16x!tt.ptr<f32>>
+// CHECK: tt.store %[[IF_RESULT]]#2
+
+module {
+  tt.func public @test_multiple_ptrs_if_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<2> : tensor<16x16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %2 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %3 = arith.cmpi ne, %arg13, %c0_i32 : i32
+    %4:2 = scf.if %3 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+      %6 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+      %7 = arith.muli %1, %6 : tensor<16x1xi32>
+      %8 = tt.splat %arg7 : i32 -> tensor<16x1xi32>
+      %9 = arith.addi %8, %7 : tensor<16x1xi32>
+      %10 = tt.splat %arg10 : i32 -> tensor<16x1xi32>
+      %11 = arith.addi %9, %10 : tensor<16x1xi32>
+      %12 = tt.broadcast %11 : tensor<16x1xi32> -> tensor<16x16xi32>
+      %13 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+      %14 = arith.addi %12, %13 : tensor<16x16xi32>
+      %15 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %16 = tt.addptr %15, %14 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      %17 = arith.divsi %14, %cst : tensor<16x16xi32>
+      %18 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %19 = tt.addptr %18, %17 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      scf.yield %16, %19 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    } else {
+      %6 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+      %7 = arith.muli %1, %6 : tensor<16x1xi32>
+      %8 = tt.splat %arg9 : i32 -> tensor<16x1xi32>
+      %9 = arith.addi %8, %7 : tensor<16x1xi32>
+      %10 = tt.splat %arg12 : i32 -> tensor<16x1xi32>
+      %11 = arith.addi %9, %10 : tensor<16x1xi32>
+      %12 = tt.broadcast %11 : tensor<16x1xi32> -> tensor<16x16xi32>
+      %13 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+      %14 = arith.addi %12, %13 : tensor<16x16xi32>
+      %15 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %16 = tt.addptr %15, %14 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      %17 = arith.divsi %14, %cst : tensor<16x16xi32>
+      %18 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %19 = tt.addptr %18, %17 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      scf.yield %16, %19 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    }
+    %5 = tt.load %4#0 : tensor<16x16x!tt.ptr<f32>>
+    tt.store %4#1, %5 : tensor<16x16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_returning_mixed_structured_ptrs.mlir
+++ b/test/Conversion/TritonToStructured/if_returning_mixed_structured_ptrs.mlir
@@ -1,0 +1,63 @@
+
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+// Test that scf.if returning multiple pointers both unstructured and structured are handled.
+
+// CHECK-LABEL: tt.func public @test_multiple_ptrs_if_kernel(
+// CHECK:         %[[COND:.*]] = arith.cmpi
+// CHECK:         %[[BASE_PTR:.*]] = arith.select %[[COND]]
+// CHECK:         %[[IF_RESULTS:.*]]:3 = scf.if %[[COND]] -> (index, index, tensor<16x16x!tt.ptr<f32>>) {
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %{{.*}} : index, index, tensor<16x16x!tt.ptr<f32>>
+// CHECK:         } else {
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %{{.*}} : index, index, tensor<16x16x!tt.ptr<f32>>
+// CHECK:         }
+// CHECK:         %[[STRUCTURED_PTR:.*]] = tts.make_tptr %[[BASE_PTR]] to sizes: [16, 16], strides: [%[[IF_RESULTS]]#1, {{%c1|1}}], offsets: [%[[IF_RESULTS]]#0, {{%c0|0}}]
+// CHECK:         %[[LOADED:.*]] = "tts.load"(%[[STRUCTURED_PTR]])
+// CHECK:         tt.store %[[IF_RESULTS]]#2, %[[LOADED]]
+// CHECK:         tt.return
+
+module {
+  tt.func public @test_multiple_ptrs_if_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<2> : tensor<16x16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %2 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %3 = arith.cmpi ne, %arg13, %c0_i32 : i32
+    %4:2 = scf.if %3 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+      %6 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+      %7 = arith.muli %1, %6 : tensor<16x1xi32>
+      %8 = tt.splat %arg7 : i32 -> tensor<16x1xi32>
+      %9 = arith.addi %8, %7 : tensor<16x1xi32>
+      %10 = tt.splat %arg10 : i32 -> tensor<16x1xi32>
+      %11 = arith.addi %9, %10 : tensor<16x1xi32>
+      %12 = tt.broadcast %11 : tensor<16x1xi32> -> tensor<16x16xi32>
+      %13 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+      %14 = arith.addi %12, %13 : tensor<16x16xi32>
+      %15 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %16 = tt.addptr %15, %14 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      %17 = arith.divsi %14, %cst : tensor<16x16xi32>
+      %18 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %19 = tt.addptr %18, %17 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      scf.yield %16, %19 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    } else {
+      %6 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+      %7 = arith.muli %1, %6 : tensor<16x1xi32>
+      %8 = tt.splat %arg9 : i32 -> tensor<16x1xi32>
+      %9 = arith.addi %8, %7 : tensor<16x1xi32>
+      %10 = tt.splat %arg12 : i32 -> tensor<16x1xi32>
+      %11 = arith.addi %9, %10 : tensor<16x1xi32>
+      %12 = tt.broadcast %11 : tensor<16x1xi32> -> tensor<16x16xi32>
+      %13 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+      %14 = arith.addi %12, %13 : tensor<16x16xi32>
+      %15 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %16 = tt.addptr %15, %14 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      %17 = arith.divsi %14, %cst : tensor<16x16xi32>
+      %18 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %19 = tt.addptr %18, %17 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      scf.yield %16, %19 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    }
+    %5 = tt.load %4#0 : tensor<16x16x!tt.ptr<f32>>
+    tt.store %4#1, %5 : tensor<16x16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_returning_mixed_structured_ptrs_nested.mlir
+++ b/test/Conversion/TritonToStructured/if_returning_mixed_structured_ptrs_nested.mlir
@@ -1,0 +1,87 @@
+
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+// Test that scf.if returning multiple pointers both unstructured and structured are handled
+// even with nested if statements.
+
+// CHECK-LABEL: tt.func public @test_multiple_ptrs_if_kernel
+// CHECK: %[[IF_RESULT:.*]]:4 = scf.if %{{.*}} -> (index, index, !tt.ptr<f32>, tensor<16x16x!tt.ptr<f32>>) {
+// CHECK:   scf.yield %{{.*}}, %{{.*}}, %arg0, %{{.*}} : index, index, !tt.ptr<f32>, tensor<16x16x!tt.ptr<f32>>
+// CHECK: } else {
+// CHECK:   %{{.*}} = arith.select %{{.*}}, %arg1, %arg2 : !tt.ptr<f32>
+// CHECK:   %{{.*}}:3 = scf.if %{{.*}} -> (index, index, tensor<16x16x!tt.ptr<f32>>) {
+// CHECK:     scf.yield %{{.*}}, %{{.*}}, %{{.*}} : index, index, tensor<16x16x!tt.ptr<f32>>
+// CHECK:   } else {
+// CHECK:     scf.yield %{{.*}}, %{{.*}}, %{{.*}} : index, index, tensor<16x16x!tt.ptr<f32>>
+// CHECK:   }
+// CHECK:   scf.yield %{{.*}}#0, %{{.*}}#1, %{{.*}}, %{{.*}}#2 : index, index, !tt.ptr<f32>, tensor<16x16x!tt.ptr<f32>>
+// CHECK: }
+// CHECK: %{{.*}} = tts.make_tptr %[[IF_RESULT]]#2 to sizes: [16, 16], strides: [%[[IF_RESULT]]#1, {{%c1|1}}], offsets: [%[[IF_RESULT]]#0, {{%c0|0}}]
+// CHECK: %[[LOAD:.*]] = "tts.load"(%{{.*}})
+// CHECK: tt.store %[[IF_RESULT]]#3, %[[LOAD]]
+
+module {
+  tt.func public @test_multiple_ptrs_if_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<2> : tensor<16x16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %2 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %3 = arith.cmpi ne, %arg13, %c0_i32 : i32
+    %4:2 = scf.if %3 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+      %6 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+      %7 = arith.muli %1, %6 : tensor<16x1xi32>
+      %8 = tt.splat %arg7 : i32 -> tensor<16x1xi32>
+      %9 = arith.addi %8, %7 : tensor<16x1xi32>
+      %10 = tt.splat %arg10 : i32 -> tensor<16x1xi32>
+      %11 = arith.addi %9, %10 : tensor<16x1xi32>
+      %12 = tt.broadcast %11 : tensor<16x1xi32> -> tensor<16x16xi32>
+      %13 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+      %14 = arith.addi %12, %13 : tensor<16x16xi32>
+      %15 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %16 = tt.addptr %15, %14 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      %17 = arith.divsi %14, %cst : tensor<16x16xi32>
+      %18 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %19 = tt.addptr %18, %17 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      scf.yield %16, %19 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    } else {
+      %6 = arith.cmpi ne, %arg14, %c0_i32 : i32
+      %7:2 = scf.if %6 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+        %8 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+        %9 = arith.muli %1, %8 : tensor<16x1xi32>
+        %10 = tt.splat %arg8 : i32 -> tensor<16x1xi32>
+        %11 = arith.addi %10, %9 : tensor<16x1xi32>
+        %12 = tt.splat %arg11 : i32 -> tensor<16x1xi32>
+        %13 = arith.addi %11, %12 : tensor<16x1xi32>
+        %14 = tt.broadcast %13 : tensor<16x1xi32> -> tensor<16x16xi32>
+        %15 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+        %16 = arith.addi %14, %15 : tensor<16x16xi32>
+        %17 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %18 = tt.addptr %17, %16 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        %19 = arith.divsi %16, %cst : tensor<16x16xi32>
+        %20 = tt.splat %arg4 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %21 = tt.addptr %20, %19 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        scf.yield %18, %21 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+      } else {
+        %8 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+        %9 = arith.muli %1, %8 : tensor<16x1xi32>
+        %10 = tt.splat %arg9 : i32 -> tensor<16x1xi32>
+        %11 = arith.addi %10, %9 : tensor<16x1xi32>
+        %12 = tt.splat %arg12 : i32 -> tensor<16x1xi32>
+        %13 = arith.addi %11, %12 : tensor<16x1xi32>
+        %14 = tt.broadcast %13 : tensor<16x1xi32> -> tensor<16x16xi32>
+        %15 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+        %16 = arith.addi %14, %15 : tensor<16x16xi32>
+        %17 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %18 = tt.addptr %17, %16 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        %19 = arith.divsi %16, %cst : tensor<16x16xi32>
+        %20 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %21 = tt.addptr %20, %19 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        scf.yield %18, %21 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+      }
+      scf.yield %7#0, %7#1 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    }
+    %5 = tt.load %4#0 : tensor<16x16x!tt.ptr<f32>>
+    tt.store %4#1, %5 : tensor<16x16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_returning_multiple_results.mlir
+++ b/test/Conversion/TritonToStructured/if_returning_multiple_results.mlir
@@ -1,0 +1,71 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @test_multiple_ptrs_if_kernel
+// CHECK: %[[OUTER_IF:.*]]:6 = scf.if %{{.*}} -> (index, index, !tt.ptr<f32>, index, index, !tt.ptr<f32>)
+// CHECK: scf.if %{{.*}} -> (index, index, index, index)
+// CHECK-NOT: scf.if {{.*}} -> (tensor<{{.*}}x!tt.ptr
+// CHECK: tts.make_tptr %[[OUTER_IF]]#2 to sizes: [16, 16], strides: [%[[OUTER_IF]]#1, {{%c1|1}}], offsets: [%[[OUTER_IF]]#0, {{%c0|0}}]
+// CHECK: tts.make_tptr %[[OUTER_IF]]#5 to sizes: [16, 16], strides: [%[[OUTER_IF]]#4, {{%c1|1}}], offsets: [%[[OUTER_IF]]#3, {{%c0|0}}]
+
+module {
+  tt.func public @test_multiple_ptrs_if_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg3: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 32 : i32}, %arg8: i32 {tt.divisibility = 32 : i32}, %arg9: i32 {tt.divisibility = 32 : i32}, %arg10: i32 {tt.divisibility = 32 : i32}, %arg11: i32 {tt.divisibility = 32 : i32}, %arg12: i32 {tt.divisibility = 32 : i32}, %arg13: i32, %arg14: i32 {tt.divisibility = 32 : i32}, %arg15: i32 {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<16xi32> -> tensor<16x1xi32>
+    %2 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %3 = arith.cmpi ne, %arg13, %c0_i32 : i32
+    %4:2 = scf.if %3 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+      %6 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+      %7 = arith.muli %1, %6 : tensor<16x1xi32>
+      %8 = tt.splat %arg7 : i32 -> tensor<16x1xi32>
+      %9 = arith.addi %8, %7 : tensor<16x1xi32>
+      %10 = tt.splat %arg10 : i32 -> tensor<16x1xi32>
+      %11 = arith.addi %9, %10 : tensor<16x1xi32>
+      %12 = tt.broadcast %11 : tensor<16x1xi32> -> tensor<16x16xi32>
+      %13 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+      %14 = arith.addi %12, %13 : tensor<16x16xi32>
+      %15 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %16 = tt.addptr %15, %14 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      %17 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+      %18 = tt.addptr %17, %14 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+      scf.yield %16, %18 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    } else {
+      %6 = arith.cmpi ne, %arg14, %c0_i32 : i32
+      %7:2 = scf.if %6 -> (tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>) {
+        %8 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+        %9 = arith.muli %1, %8 : tensor<16x1xi32>
+        %10 = tt.splat %arg8 : i32 -> tensor<16x1xi32>
+        %11 = arith.addi %10, %9 : tensor<16x1xi32>
+        %12 = tt.splat %arg11 : i32 -> tensor<16x1xi32>
+        %13 = arith.addi %11, %12 : tensor<16x1xi32>
+        %14 = tt.broadcast %13 : tensor<16x1xi32> -> tensor<16x16xi32>
+        %15 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+        %16 = arith.addi %14, %15 : tensor<16x16xi32>
+        %17 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %18 = tt.addptr %17, %16 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        %19 = tt.splat %arg4 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %20 = tt.addptr %19, %16 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        scf.yield %18, %20 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+      } else {
+        %8 = tt.splat %arg6 : i32 -> tensor<16x1xi32>
+        %9 = arith.muli %1, %8 : tensor<16x1xi32>
+        %10 = tt.splat %arg9 : i32 -> tensor<16x1xi32>
+        %11 = arith.addi %10, %9 : tensor<16x1xi32>
+        %12 = tt.splat %arg12 : i32 -> tensor<16x1xi32>
+        %13 = arith.addi %11, %12 : tensor<16x1xi32>
+        %14 = tt.broadcast %13 : tensor<16x1xi32> -> tensor<16x16xi32>
+        %15 = tt.broadcast %2 : tensor<1x16xi32> -> tensor<16x16xi32>
+        %16 = arith.addi %14, %15 : tensor<16x16xi32>
+        %17 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %18 = tt.addptr %17, %16 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        %19 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>>
+        %20 = tt.addptr %19, %16 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16xi32>
+        scf.yield %18, %20 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+      }
+      scf.yield %7#0, %7#1 : tensor<16x16x!tt.ptr<f32>>, tensor<16x16x!tt.ptr<f32>>
+    }
+    %5 = tt.load %4#0 : tensor<16x16x!tt.ptr<f32>>
+    tt.store %4#1, %5 : tensor<16x16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_simple_addptr.mlir
+++ b/test/Conversion/TritonToStructured/if_simple_addptr.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @simple_addptr
+// CHECK-DAG: %c32 = arith.constant 32 : index
+// CHECK-DAG: %c16 = arith.constant 16 : index
+// CHECK: %[[OFF:.*]] = arith.select{{.*}}%c16, %c32 : index
+// CHECK-NOT: scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK: tts.make_tptr %arg0 to sizes: [16], strides: [{{%c1|1}}], offsets: [%[[OFF]]]{{.*}}: <f32> to tensor<16x!tt.ptr<f32>>
+
+module {
+  tt.func public @simple_addptr(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.get_program_id x : i32
+    %2 = arith.remsi %1, %c2_i32 : i32
+    %3 = arith.cmpi eq, %2, %c0_i32 : i32
+    %4 = scf.if %3 -> (!tt.ptr<f32>) {
+      %10 = tt.addptr %arg0, %c16_i32 : !tt.ptr<f32>, i32
+      scf.yield %10 : !tt.ptr<f32>
+    } else {
+      %10 = tt.addptr %arg0, %c32_i32 : !tt.ptr<f32>, i32
+      scf.yield %10 : !tt.ptr<f32>
+    }
+    %5 = tt.splat %4 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %7 = tt.load %6 : tensor<16x!tt.ptr<f32>>
+    %8 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    tt.store %9, %7 : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/if_tensor_offset_in_conditional_kernel.mlir
+++ b/test/Conversion/TritonToStructured/if_tensor_offset_in_conditional_kernel.mlir
@@ -1,0 +1,131 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: tt.func public @tensor_offset_in_conditional_kernel
+// CHECK: %[[PTR:.*]] = scf.if %{{.*}} -> (!tt.ptr<f32>) {
+// CHECK: } else {
+// CHECK:   %{{.*}} = arith.select %{{.*}}, %arg1, %arg2 : !tt.ptr<f32>
+// CHECK: }
+// CHECK: %[[OFFSET_STRIDE:.*]]:2 = scf.if %{{.*}} -> (index, index) {
+// CHECK: } else {
+// CHECK: }
+// CHECK: %[[COL_OFFSET:.*]] = scf.if %{{.*}} -> (index) {
+// CHECK: } else {
+// CHECK: }
+// CHECK: %[[ROW_OFFSET:.*]] = arith.addi %[[OFFSET_STRIDE]]#0, %[[COL_OFFSET]] : index
+// CHECK-NOT: scf.if{{.*}}tensor<{{.*}}!tt.ptr
+// CHECK: %{{.*}} = tts.make_tptr %[[PTR]] to sizes: [32, 16], strides: [%[[OFFSET_STRIDE]]#1, {{%c1|1}}], offsets: [%[[ROW_OFFSET]], {{%c0|0}}], shape: [0, 0], order: []
+// CHECK: %[[STRIDE:.*]] = scf.if %{{.*}} -> (index) {
+// CHECK: } else {
+// CHECK: }
+// CHECK: %{{.*}} = tts.make_tptr %arg20 to sizes: [32, 16], strides: [%[[STRIDE]], {{%c1|1}}], offsets: [{{%c0|0}}, {{%c0|0}}], shape: [0, 0], order: []
+
+module {
+  tt.func public @tensor_offset_in_conditional_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32, %arg8: i32, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32, %arg13: i32 {tt.divisibility = 16 : i32}, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32, %arg17: i32, %arg18: i32 {tt.divisibility = 16 : i32}, %arg19: i32 {tt.divisibility = 16 : i32}, %arg20: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<1> : tensor<1x16xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi ne, %arg3, %c0_i32 : i32
+    %1 = scf.if %0 -> (!tt.ptr<f32>) {
+      scf.yield %arg0 : !tt.ptr<f32>
+    } else {
+      %21 = arith.cmpi ne, %arg4, %c0_i32 : i32
+      %22 = arith.select %21, %arg1, %arg2 : !tt.ptr<f32>
+      scf.yield %22 : !tt.ptr<f32>
+    }
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = arith.cmpi ne, %arg12, %c0_i32 : i32
+    %4 = scf.if %3 -> (tensor<32x1xi32>) {
+      %21 = tt.expand_dims %2 {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+      %22 = tt.splat %arg9 : i32 -> tensor<32x1xi32>
+      %23 = arith.muli %21, %22 : tensor<32x1xi32>
+      %24 = tt.splat %arg6 : i32 -> tensor<32x1xi32>
+      %25 = arith.addi %24, %23 : tensor<32x1xi32>
+      scf.yield %25 : tensor<32x1xi32>
+    } else {
+      %21 = arith.cmpi ne, %arg13, %c0_i32 : i32
+      %22 = scf.if %21 -> (tensor<32x1xi32>) {
+        %23 = tt.expand_dims %2 {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+        %24 = tt.splat %arg10 : i32 -> tensor<32x1xi32>
+        %25 = arith.muli %23, %24 : tensor<32x1xi32>
+        %26 = tt.splat %arg7 : i32 -> tensor<32x1xi32>
+        %27 = arith.addi %26, %25 : tensor<32x1xi32>
+        scf.yield %27 : tensor<32x1xi32>
+      } else {
+        %23 = tt.expand_dims %2 {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+        %24 = tt.splat %arg11 : i32 -> tensor<32x1xi32>
+        %25 = arith.muli %23, %24 : tensor<32x1xi32>
+        %26 = tt.splat %arg8 : i32 -> tensor<32x1xi32>
+        %27 = arith.addi %26, %25 : tensor<32x1xi32>
+        scf.yield %27 : tensor<32x1xi32>
+      }
+      scf.yield %22 : tensor<32x1xi32>
+    }
+    %5 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %6 = arith.cmpi ne, %arg17, %c0_i32 : i32
+    %7 = scf.if %6 -> (tensor<1x16xi32>) {
+      %21 = tt.expand_dims %5 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+      %22 = tt.splat %arg15 : i32 -> tensor<1x16xi32>
+      %23 = arith.addi %22, %21 : tensor<1x16xi32>
+      scf.yield %23 : tensor<1x16xi32>
+    } else {
+      %21 = arith.cmpi ne, %arg18, %c0_i32 : i32
+      %22 = scf.if %21 -> (tensor<1x16xi32>) {
+        %23 = tt.expand_dims %5 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+        %24 = arith.addi %23, %cst : tensor<1x16xi32>
+        scf.yield %24 : tensor<1x16xi32>
+      } else {
+        %23 = tt.expand_dims %5 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+        %24 = tt.splat %arg16 : i32 -> tensor<1x16xi32>
+        %25 = arith.addi %24, %23 : tensor<1x16xi32>
+        scf.yield %25 : tensor<1x16xi32>
+      }
+      scf.yield %22 : tensor<1x16xi32>
+    }
+    %8 = tt.splat %1 : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %4 : tensor<32x1x!tt.ptr<f32>>, tensor<32x1xi32>
+    %10 = tt.broadcast %9 : tensor<32x1x!tt.ptr<f32>> -> tensor<32x16x!tt.ptr<f32>>
+    %11 = tt.broadcast %7 : tensor<1x16xi32> -> tensor<32x16xi32>
+    %12 = tt.addptr %10, %11 : tensor<32x16x!tt.ptr<f32>>, tensor<32x16xi32>
+    %13 = tt.load %12 : tensor<32x16x!tt.ptr<f32>>
+    %14 = scf.if %3 -> (tensor<32x1xi32>) {
+      %21 = tt.expand_dims %2 {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+      %22 = tt.splat %arg9 : i32 -> tensor<32x1xi32>
+      %23 = arith.muli %21, %22 : tensor<32x1xi32>
+      scf.yield %23 : tensor<32x1xi32>
+    } else {
+      %21 = arith.cmpi ne, %arg13, %c0_i32 : i32
+      %22 = scf.if %21 -> (tensor<32x1xi32>) {
+        %23 = tt.expand_dims %2 {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+        %24 = tt.splat %arg10 : i32 -> tensor<32x1xi32>
+        %25 = arith.muli %23, %24 : tensor<32x1xi32>
+        scf.yield %25 : tensor<32x1xi32>
+      } else {
+        %23 = tt.expand_dims %2 {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+        %24 = tt.splat %arg11 : i32 -> tensor<32x1xi32>
+        %25 = arith.muli %23, %24 : tensor<32x1xi32>
+        scf.yield %25 : tensor<32x1xi32>
+      }
+      scf.yield %22 : tensor<32x1xi32>
+    }
+    %15 = scf.if %6 -> (tensor<1x16xi32>) {
+      %21 = tt.expand_dims %5 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+      scf.yield %21 : tensor<1x16xi32>
+    } else {
+      %21 = arith.cmpi ne, %arg18, %c0_i32 : i32
+      %22 = scf.if %21 -> (tensor<1x16xi32>) {
+        %23 = tt.expand_dims %5 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+        scf.yield %23 : tensor<1x16xi32>
+      } else {
+        %23 = tt.expand_dims %5 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+        scf.yield %23 : tensor<1x16xi32>
+      }
+      scf.yield %22 : tensor<1x16xi32>
+    }
+    %16 = tt.splat %arg20 : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>>
+    %17 = tt.addptr %16, %14 : tensor<32x1x!tt.ptr<f32>>, tensor<32x1xi32>
+    %18 = tt.broadcast %17 : tensor<32x1x!tt.ptr<f32>> -> tensor<32x16x!tt.ptr<f32>>
+    %19 = tt.broadcast %15 : tensor<1x16xi32> -> tensor<32x16xi32>
+    %20 = tt.addptr %18, %19 : tensor<32x16x!tt.ptr<f32>>, tensor<32x16xi32>
+    tt.store %20, %13 : tensor<32x16x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/tensor_indices_loop_iterargs_not_used_ptranalysis_prepass.mlir
+++ b/test/Conversion/TritonToStructured/tensor_indices_loop_iterargs_not_used_ptranalysis_prepass.mlir
@@ -28,16 +28,16 @@ module {
 // CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<4> : tensor<4xi32>
 // CHECK-DAG:       [[VAR_0_:%.+]] = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tt.splat [[arg0_]] : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
-// CHECK-DAG:       [[structured_:%.+]], [[offsets_:%.+]], [[VAR_strides_:%.+]] = "tts.get_structured_state"([[VAR_0_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
-// CHECK-DAG:       [[VAR_2_:%.+]]:6 = scf.for [[VAR_arg1_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg2_:%.+]] = [[structured_]], [[VAR_arg3_:%.+]] = [[offsets_]], [[VAR_arg4_:%.+]] = [[VAR_strides_]], [[VAR_arg5_:%.+]] = [[structured_]], [[VAR_arg6_:%.+]] = [[offsets_]], [[VAR_arg7_:%.+]] = [[VAR_strides_]]) -> (tensor<4xi32>, index, index, tensor<4xi32>, index, index)  : i32 {
+// CHECK-DAG:       [[structured_:%.+]], [[offsets_:%.+]], [[VAR_strides_:%.+]], [[VAR_src_:%.+]] = "tts.get_structured_state"([[VAR_0_]]) <{resultSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index, !tt.ptr<none>)
+// CHECK-DAG:       [[VAR_2_:%.+]]:8 = scf.for [[VAR_arg1_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg2_:%.+]] = [[structured_]], [[VAR_arg3_:%.+]] = [[offsets_]], [[VAR_arg4_:%.+]] = [[VAR_strides_]], [[VAR_arg_src_:%.+]] = [[VAR_src_]], [[VAR_arg5_:%.+]] = [[structured_]], [[VAR_arg6_:%.+]] = [[offsets_]], [[VAR_arg7_:%.+]] = [[VAR_strides_]], [[VAR_arg_src_2_:%.+]] = [[VAR_src_]]) -> (tensor<4xi32>, index, index, !tt.ptr<none>, tensor<4xi32>, index, index, !tt.ptr<none>)  : i32 {
 // CHECK-DAG:         [[VAR_3_:%.+]] = tt.addptr [[VAR_1_]], [[VAR_arg2_]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 // CHECK-DAG:         [[VAR_4_:%.+]] = arith.sitofp [[VAR_arg5_]] : tensor<4xi32> to tensor<4xf32>
 // CHECK:             tt.store [[VAR_3_]], [[VAR_4_]] : tensor<4x!tt.ptr<f32>>
 // CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_arg2_]], [[VAR_cst_]] : tensor<4xi32>
 // CHECK-DAG:         [[VAR_6_:%.+]] = arith.addi [[VAR_arg5_]], [[VAR_cst_]] : tensor<4xi32>
-// CHECK-DAG:         [[structured_3_:%.+]], [[offsets_4_:%.+]], [[VAR_strides_5_:%.+]] = "tts.get_structured_state"([[VAR_5_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
-// CHECK-DAG:         [[structured_6_:%.+]], [[offsets_7_:%.+]], [[VAR_strides_8_:%.+]] = "tts.get_structured_state"([[VAR_6_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
-// CHECK:             scf.yield [[structured_3_]], [[offsets_4_]], [[VAR_strides_5_]], [[structured_6_]], [[offsets_7_]], [[VAR_strides_8_]] : tensor<4xi32>, index, index, tensor<4xi32>, index, index
+// CHECK-DAG:         [[structured_3_:%.+]], [[offsets_4_:%.+]], [[VAR_strides_5_:%.+]], [[VAR_src_6_:%.+]] = "tts.get_structured_state"([[VAR_5_]]) <{resultSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index, !tt.ptr<none>)
+// CHECK-DAG:         [[structured_7_:%.+]], [[offsets_8_:%.+]], [[VAR_strides_9_:%.+]], [[VAR_src_10_:%.+]] = "tts.get_structured_state"([[VAR_6_]]) <{resultSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index, !tt.ptr<none>)
+// CHECK:             scf.yield [[structured_3_]], [[offsets_4_]], [[VAR_strides_5_]], [[VAR_src_6_]], [[structured_7_]], [[offsets_8_]], [[VAR_strides_9_]], [[VAR_src_10_]] : tensor<4xi32>, index, index, !tt.ptr<none>, tensor<4xi32>, index, index, !tt.ptr<none>
 // CHECK:           }
 // CHECK:           tt.return
 // CHECK:         }


### PR DESCRIPTION
We have internally implemented control-flow support for `PtrAnalysis`. This allows the `triton-to-structured` pass to generate block-pointers in presence of control-flow operations such as `scf.if`. We would appreciate any feedbacks!

# General control flow support in PtrAnalysis

## Background

PtrAnalysis supports loops (`scf.for`) but fails on conditionals (`scf.if`) that produce pointers, requiring us to fallback to scalar loads and stores. Where applicable, we want the analysis to identify structured loads and stores and lower them to more efficient DMA operations.

## The Problem

Pointer analysis recursively visits operations and produces `PtrState` for each op: source pointer, offsets, strides, etc.

**Challenge**: An `scf.if` produces **two pointer states** (one per branch) that must be reconciled into a single result state.

```mlir
%result_ptr = scf.if %cond -> (!tt.ptr<f32>) {
  %then_ptr = ... // PtrStateThen
  scf.yield %then_ptr
} else {
  %else_ptr = ... // PtrStateElse
  scf.yield %else_ptr
}
// What is the PtrState of %result_ptr?
```

**Solution**: Leverage existing transformation that exposes the pointer states through `tts.get_structured_state` to derive the correct pointer states that represent both branches. This allows the analysis to correctly populate the pointer state for `scf.if` operations.

## Solutions

### Background on `tts.get_structured_state`

This operation decouples **analysis** from **IR rewriting**:

1.  **Pre-pass**: Inserts `tts.get_structured_state` ops in strategic places where an operation can produce `PtrState`.
2.  **Analysis**: Builds `PtrState` for each operation.
3.  **Rewrite**: Process all `tts.get_structured_state` ops and replace the ***uses*** of their return values with the correct offsets and strides populated during step 2.

Example for `scf.for`:

``` mlir
%arg_ptr, %arg_offset, %arg_stride = tts.get_structured_state ...
%ptr, %offset, %stride = scf.for ... iter_args(%arg_ptr, %arg_offset, %arg_stride) {
  scf.yield %next_ptr, %computed_offset, %computed_stride
}

```

### 1. Reconciling states using `scf.if` results

Leverage existing `tts.get_structured_state` infrastructure: make `scf.if` yield **all PtrState components** (offsets, strides, **and source**). The reconciled state then references the `scf.if` results directly:

``` mlir
%ptr, %offset, %stride, %source = scf.if %cond -> (!tt.ptr<f32>, index, index, !tt.ptr<f32>) {
  scf.yield %then_ptr, %then_offset, %then_stride, %then_source
} else {
  scf.yield %else_ptr, %else_offset, %else_stride, %else_source
}
// PtrState for %result_ptr: { source: %source, offsets: [%offset], strides: [%stride] }
```

This creates “phi nodes” for each state component and is the key solution to generalized control flow support since the analysis can now recursively visit across arbitrary control-flow ops.

### 2. `tts.make_tptr` after each condition

When ops need a structured pointer from `scf.if`, insert a single `tts.make_tptr` **after** the conditional:

``` mlir
%offset, %stride, %source = scf.if %cond {
  ...
}

%structured_ptr = tts.make_tptr %source to sizes: [...], strides: [%stride], offsets: [%offset], ...
%data = tts.load %structured_ptr

```

**Why not inside each branch?**

  * `tts.make_tptr` is a **descriptor operation** that encodes how memory should be accessed, not a value-producing operation.
  * Using the `tts.make_tptr` result in each branch will also confuse the bufferization pass.

### 3. Handling Mixed Structured/Unstructured Branches

When branches produce incompatible structuredness (e.g.: one is structured when the other isn’t), we will fallback to using unstructured pointers. Handling this problem is tricky in practice, especially in nested `scf.if`.

**Example:**

Assume that:

  * the first outer-most if branch returns **unstructured** pointers and
  * the second outer-most if branch (and its nested branches) return **structured** pointers.

``` mlir
%4:12 = scf.if %3 -> {
  %unstructured_0, %offsets_1:2,... = "tts.get_structured_state"
  scf.yield %unstructured_0, %offsets#0,...
} else {
  %7:12 = scf.if %6 -> {
    %structured, %offsets:2,... = "tts.get_structured_state"
    %structured_0, %offsets_1:2,... = "tts.get_structured_state"
    scf.yield %structured, %offsets#0,...
  } else {
    %structured, %offsets:2,... = "tts.get_structured_state"
    %structured_0, %offsets_1:2,... = "tts.get_structured_state"
    scf.yield %structured, %offsets#0,...
  }
  scf.yield %7#0, %7#1, %7#2,...
}
```

Since both branches are incompatible, we want to use unstructured pointers for this `scf.if`. However, since the `tts.get_structured_state` operations are processed independently, marking an operation to be skipped during rewriting because other `tts.get_structured_state` have failed is tricky.

For such cases, for simplicity, we will mark all nested operations inside the `scf.if` to be unstructured since it is not likely that users will write such code.

### 4. Extension to handling pointers returned by other control-flow ops

The above approach also scales to other kinds of control-flow ops that return pointers such as `scf.for`, `scf.while`,… We just need to create the appropriate visit and rewrite methods for such operations.

## Conclusion

This work provides a framework for supporting arbitrary control-flow within the triton-to-structured pass by leveraging the existing transformation provided by the `tts.get_structured_state` transformation.