### PR TITLE
Add structured atomic lowering

### DIFF
--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -358,6 +358,11 @@ public:
 
   LogicalResult rewriteStoreOp(triton::StoreOp op, bool useUnsafeMask = false);
 
+  LogicalResult rewriteAtomicRMWOp(triton::AtomicRMWOp op,
+                                   bool useUnsafeMask = false);
+
+  LogicalResult rewriteAtomicCASOp(triton::AtomicCASOp op);
+
   LogicalResult rewriteOp(Operation *op, bool useUnsafeMask = false);
 };
 

--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -326,6 +326,8 @@ def TTS_LoadOp : TTS_Op<"load", [
     }
   }];
 
+  let hasFolder = 1;
+
   // TODO
   //let hasCustomAssemblyFormat = 1;
   //let hasVerifier = 1;
@@ -356,6 +358,8 @@ def TTS_StoreOp : TTS_Op<"store", [
       return !getMixedMaskDims().empty();
     }
   }];
+
+  let hasFolder = 1;
 
   // TODO
   //let hasCustomAssemblyFormat = 1;

--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -11,6 +11,7 @@
 include "mlir/IR/OpBase.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 
 def Triton_Structured_Dialect : Dialect {
   let name = "tts";
@@ -364,6 +365,90 @@ def TTS_StoreOp : TTS_Op<"store", [
   // TODO
   //let hasCustomAssemblyFormat = 1;
   //let hasVerifier = 1;
+}
+
+def TTS_AtomicRMWOp : TTS_Op<"atomic_rmw", [
+  MemoryEffects<[MemWrite, MemRead]>
+]> {
+  let summary = "atomic read-modify-write";
+
+  let description = [{
+    Load the old value at $ptr, apply $atomic_rmw_op with $val, store the
+    result back to $ptr, and return the old value.
+  }];
+
+  let arguments = (ins
+    TT_AtomicRMWAttr:$atomic_rmw_op,
+    TT_PtrLike:$ptr,
+    TT_Tensor:$val,
+    Variadic<Index>:$mask_dims,
+    DenseI64ArrayAttr:$static_mask_dims,
+    TT_MemSemanticAttr:$sem,
+    TT_MemSyncScopeAttr:$scope
+  );
+
+  let results = (outs TT_Tensor:$result);
+
+  let builders = [
+    OpBuilder<(ins "triton::RMWOp":$atomic_rmw_op, "Value":$ptr, "Value":$value, "ArrayRef<OpFoldResult>":$dims, "triton::MemSemantic":$sem, "triton::MemSyncScope":$scope)>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return a vector of all the static or dynamic fields
+    SmallVector<OpFoldResult> getMixedMaskDims() {
+      Builder b(getContext());
+      return ::mlir::getMixedValues(getStaticMaskDims(), getMaskDims(), b);
+    }
+
+    bool hasMask() {
+      return !getMixedMaskDims().empty();
+    }
+  }];
+
+  let hasFolder = 1;
+
+  // Explicitly list $atomic_rmw_op, $sem, and $scope rather than relying on
+  // attr-dict so they're printed as strings rather than opaque integers.
+  let assemblyFormat = [{
+    $atomic_rmw_op `,` $sem `,` $scope `,` $ptr `,` $val (`,` $mask_dims^)? attr-dict `:`
+    functional-type(operands, $result)
+  }];
+
+  let hasVerifier = 1;
+}
+
+def TTS_AtomicCASOp : TTS_Op<"atomic_cas", [
+  MemoryEffects<[MemWrite, MemRead]>
+]> {
+  let summary = "atomic compare-and-swap";
+
+  let description = [{
+    Compare $cmp with the old value at $ptr. Store $val when they match,
+    otherwise keep the old value, and return the old value.
+  }];
+
+  let arguments = (ins
+    TT_PtrLike:$ptr,
+    TT_Tensor:$cmp,
+    TT_Tensor:$val,
+    TT_MemSemanticAttr:$sem,
+    TT_MemSyncScopeAttr:$scope
+  );
+
+  let results = (outs TT_Tensor:$result);
+
+  let builders = [
+    OpBuilder<(ins "triton::MemSemantic":$sem, "triton::MemSyncScope":$scope, "Value":$ptr, "Value":$cmp, "Value":$val)>,
+  ];
+
+  // Explicitly list $sem and $scope rather than relying on attr-dict so
+  // they're printed as strings rather than opaque integers.
+  let assemblyFormat = [{
+    $sem `,` $scope `,` $ptr `,` $cmp `,` $val attr-dict `:`
+    functional-type(operands, $result)
+  }];
+
+  let hasVerifier = 1;
 }
 
 #endif // TRITON_STRUCTURED_DIALECT

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -1748,6 +1748,97 @@ LogicalResult PtrAnalysis::rewriteStoreOp(triton::StoreOp op,
   return success();
 }
 
+LogicalResult PtrAnalysis::rewriteAtomicRMWOp(triton::AtomicRMWOp op,
+                                              bool useUnsafeMask) {
+  auto ptr = ptrMap.lookupOrNull(op.getPtr());
+  auto val = op.getVal();
+  auto mask = op.getMask();
+  auto loc = op.getLoc();
+
+  auto atomicRmwOp = op.getAtomicRmwOp();
+  auto sem = op.getSem();
+  auto scope = op.getScope();
+
+  if (!ptr) {
+    LLVM_DEBUG(op->emitRemark(
+        "PtrAnalysis: pointer is not replace with tts.make_tptr so "
+        "atomicRMWOp cannot be rewritten"));
+    return failure();
+  }
+
+  auto ptrType = dyn_cast<triton::PointerType>(ptr.getType());
+  if (ptrType && !isa<ShapedType>(ptrType.getPointeeType())) {
+    LLVM_DEBUG(op->emitRemark(
+        "PtrAnalysis: scalar atomicRMWOp will not be rewritten"));
+    return failure();
+  }
+
+  ArrayRef<OpFoldResult> dims;
+  mlir::triton::MaskState mstate(useUnsafeMask);
+
+  OpBuilder builder(op);
+
+  // Analyze the mask operand to determine at runtime the size of the data
+  // are moving.
+  if (mask) {
+    if (mstate.parse(mask, loc, builder).failed()) {
+      LLVM_DEBUG(op->emitRemark("MaskAnalysis failed"));
+      return failure();
+    }
+    dims = mstate.dims;
+  }
+
+  auto newOp = tts::AtomicRMWOp::create(builder, loc, atomicRmwOp, ptr, val,
+                                        dims, sem, scope);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "creating tts::atomic_rmw:\n";
+    newOp->dump();
+  });
+
+  op.replaceAllUsesWith(newOp.getResult());
+  op->erase();
+  return success();
+}
+
+LogicalResult PtrAnalysis::rewriteAtomicCASOp(triton::AtomicCASOp op) {
+  auto ptr = ptrMap.lookupOrNull(op.getPtr());
+  auto cmp = op.getCmp();
+  auto val = op.getVal();
+  auto loc = op.getLoc();
+
+  auto sem = op.getSem();
+  auto scope = op.getScope();
+
+  if (!ptr) {
+    LLVM_DEBUG(op->emitRemark(
+        "PtrAnalysis: pointer is not replace with tts.make_tptr so "
+        "atomicCASOp cannot be rewritten"));
+    return failure();
+  }
+
+  auto ptrType = dyn_cast<triton::PointerType>(ptr.getType());
+  if (ptrType && !isa<ShapedType>(ptrType.getPointeeType())) {
+    LLVM_DEBUG(op->emitRemark(
+        "PtrAnalysis: scalar atomicCASOp will not be rewritten"));
+    return failure();
+  }
+
+  OpBuilder builder(op);
+
+  auto newOp =
+      tts::AtomicCASOp::create(builder, loc, sem, scope, ptr, cmp, val);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "creating tts::atomic_cas:\n";
+    newOp->dump();
+  });
+
+  op.replaceAllUsesWith(newOp.getResult());
+  op->erase();
+  return success();
+}
+
 LogicalResult PtrAnalysis::rewriteOp(Operation *rootOp, bool useUnsafeMask) {
   LLVM_DEBUG({
     llvm::dbgs() << "rewriting rootOp\n";
@@ -1759,6 +1850,22 @@ LogicalResult PtrAnalysis::rewriteOp(Operation *rootOp, bool useUnsafeMask) {
       return WalkResult::advance();
     }
     return TypeSwitch<Operation *, WalkResult>(op)
+        .Case<triton::AtomicRMWOp>([&](auto atomicRmwOp) {
+          if (rewriteAtomicRMWOp(atomicRmwOp, useUnsafeMask).failed()) {
+            LLVM_DEBUG(atomicRmwOp->emitRemark(
+                "PtrAnalysis: Failed to rewrite AtomicRMWOp"));
+            return WalkResult::advance();
+          }
+          return WalkResult::skip();
+        })
+        .Case<triton::AtomicCASOp>([&](auto atomicCasOp) {
+          if (rewriteAtomicCASOp(atomicCasOp).failed()) {
+            LLVM_DEBUG(atomicCasOp->emitRemark(
+                "PtrAnalysis: Failed to rewrite AtomicCASOp"));
+            return WalkResult::advance();
+          }
+          return WalkResult::skip();
+        })
         .Case<triton::AddPtrOp>([&](auto addptr) {
           if (rewriteAddptrOp(addptr).failed()) {
             LLVM_DEBUG(

--- a/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
+++ b/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <type_traits>
 #include <utility>
 
 #define GET_OP_CLASSES
@@ -105,6 +106,32 @@ Value getScalarValue(Value operand, Location loc, OpBuilder &builder) {
 }
 
 } // namespace utils
+
+template <typename T, typename = std::enable_if_t<
+                          llvm::is_one_of<T, LoadOp, StoreOp>::value>>
+static auto foldMemoryAccessOp(T op) {
+  SmallVector<OpFoldResult> mixedMaskDims(op.getMixedMaskDims());
+
+  // No constant operands were folded, just return.
+  if (failed(foldDynamicIndexList(mixedMaskDims, /*onlyNonNegative=*/true))) {
+    if constexpr (std::is_same_v<T, StoreOp>) {
+      return failure();
+    } else {
+      return OpFoldResult{};
+    }
+  }
+
+  auto [staticMaskDims, variableMaskDims] = decomposeMixedValues(mixedMaskDims);
+
+  op.setStaticMaskDims(staticMaskDims);
+  op.getMaskDimsMutable().assign(variableMaskDims);
+
+  if constexpr (std::is_same_v<T, StoreOp>) {
+    return success();
+  } else {
+    return OpFoldResult{op.getResult()};
+  }
+}
 
 void MakeTensorPtrOp::build(OpBuilder &b, OperationState &state, Value base,
                             ArrayRef<int64_t> sizes,
@@ -303,6 +330,8 @@ LogicalResult MakeGatherScatterTensorPtrOp::verify() {
   return success();
 }
 
+OpFoldResult LoadOp::fold(FoldAdaptor) { return foldMemoryAccessOp(*this); }
+
 void LoadOp::build(OpBuilder &b, OperationState &state, Value ptr,
                    ArrayRef<OpFoldResult> dims, Value other) {
   SmallVector<int64_t> staticDims;
@@ -328,6 +357,10 @@ void LoadOp::build(OpBuilder &b, OperationState &state, Value ptr,
   }
   build(b, state, resType, ptr, dynamicDims, b.getDenseI64ArrayAttr(staticDims),
         other);
+}
+
+LogicalResult StoreOp::fold(FoldAdaptor, SmallVectorImpl<OpFoldResult> &) {
+  return foldMemoryAccessOp(*this);
 }
 
 void StoreOp::build(OpBuilder &b, OperationState &state, Value ptr, Value value,

--- a/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
+++ b/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
@@ -107,8 +107,8 @@ Value getScalarValue(Value operand, Location loc, OpBuilder &builder) {
 
 } // namespace utils
 
-template <typename T, typename = std::enable_if_t<
-                          llvm::is_one_of<T, LoadOp, StoreOp>::value>>
+template <typename T, typename = std::enable_if_t<llvm::is_one_of<
+                          T, LoadOp, StoreOp, AtomicRMWOp>::value>>
 static auto foldMemoryAccessOp(T op) {
   SmallVector<OpFoldResult> mixedMaskDims(op.getMixedMaskDims());
 
@@ -371,6 +371,145 @@ void StoreOp::build(OpBuilder &b, OperationState &state, Value ptr, Value value,
   dispatchIndexOpFoldResults(dims, dynamicDims, staticDims);
 
   build(b, state, ptr, value, dynamicDims, b.getDenseI64ArrayAttr(staticDims));
+}
+
+OpFoldResult AtomicRMWOp::fold(FoldAdaptor) {
+  return foldMemoryAccessOp(*this);
+}
+
+void AtomicRMWOp::build(OpBuilder &b, OperationState &state,
+                        triton::RMWOp atomicRmwOp, Value ptr, Value value,
+                        ArrayRef<OpFoldResult> dims, triton::MemSemantic sem,
+                        triton::MemSyncScope scope) {
+  SmallVector<int64_t> staticDims;
+  SmallVector<Value> dynamicDims;
+
+  dispatchIndexOpFoldResults(dims, dynamicDims, staticDims);
+
+  Type resType;
+  if (auto ptrTensorType = dyn_cast<RankedTensorType>(ptr.getType())) {
+    // Non-block pointer type.
+    auto ptrType = cast<triton::PointerType>(ptrTensorType.getElementType());
+    auto elemType = ptrType.getPointeeType();
+    resType = RankedTensorType::get(ptrTensorType.getShape(), elemType);
+  } else if (auto tensorPtrType =
+                 dyn_cast<triton::PointerType>(ptr.getType())) {
+    // Block pointer type.
+    auto tensorType = cast<ShapedType>(tensorPtrType.getPointeeType());
+    resType = RankedTensorType::get(tensorType.getShape(),
+                                    tensorType.getElementType());
+  }
+
+  build(b, state, resType, atomicRmwOp, ptr, value, dynamicDims,
+        b.getDenseI64ArrayAttr(staticDims), sem, scope);
+}
+
+LogicalResult AtomicRMWOp::verify() {
+  auto rmwKind = getAtomicRmwOpAttr().getValue();
+  auto ptr = getPtr();
+  auto val = getVal();
+
+  Type ptrElemType;
+  if (auto ptrTensorType = dyn_cast<RankedTensorType>(ptr.getType())) {
+    auto ptrType = cast<triton::PointerType>(ptrTensorType.getElementType());
+    ptrElemType = ptrType.getPointeeType();
+  } else if (auto tensorPtrType =
+                 dyn_cast<triton::PointerType>(ptr.getType())) {
+    auto tensorType = cast<ShapedType>(tensorPtrType.getPointeeType());
+    ptrElemType = tensorType.getElementType();
+  } else {
+    return emitOpError(
+        "ptr must be either a tensor of pointers or a pointer to tensor");
+  }
+
+  auto valTensorType = dyn_cast<RankedTensorType>(val.getType());
+  if (!valTensorType) {
+    return emitOpError("val must be a tensor");
+  }
+
+  Type valElemType = valTensorType.getElementType();
+  if (ptrElemType != valElemType) {
+    return emitOpError("ptr and val must have the same element type, got ")
+           << ptrElemType << " and " << valElemType;
+  }
+
+  // Triton MIN/MAX are signed integer operations. The frontend emits UMIN/UMAX
+  // for unsigned integer min/max and lowers floating point min/max separately.
+  if (rmwKind == mlir::triton::RMWOp::MAX ||
+      rmwKind == mlir::triton::RMWOp::MIN ||
+      rmwKind == mlir::triton::RMWOp::UMAX ||
+      rmwKind == mlir::triton::RMWOp::UMIN) {
+    if (!ptrElemType.isInteger()) {
+      return emitOpError(
+                 "MIN/MAX/UMIN/UMAX operations require integer element type, "
+                 "got ")
+             << ptrElemType;
+    }
+  }
+
+  return success();
+}
+
+void AtomicCASOp::build(OpBuilder &b, OperationState &state,
+                        triton::MemSemantic sem, triton::MemSyncScope scope,
+                        Value ptr, Value cmp, Value val) {
+  Type resType;
+  if (auto ptrTensorType = dyn_cast<RankedTensorType>(ptr.getType())) {
+    // Non-block pointer type.
+    auto ptrType = cast<triton::PointerType>(ptrTensorType.getElementType());
+    auto elemType = ptrType.getPointeeType();
+    resType = RankedTensorType::get(ptrTensorType.getShape(), elemType);
+  } else if (auto tensorPtrType =
+                 dyn_cast<triton::PointerType>(ptr.getType())) {
+    // Block pointer type.
+    auto tensorType = cast<ShapedType>(tensorPtrType.getPointeeType());
+    resType = RankedTensorType::get(tensorType.getShape(),
+                                    tensorType.getElementType());
+  }
+
+  build(b, state, resType, ptr, cmp, val, sem, scope);
+}
+
+LogicalResult AtomicCASOp::verify() {
+  auto ptr = getPtr();
+  auto cmp = getCmp();
+  auto val = getVal();
+
+  Type ptrElemType;
+  if (auto ptrTensorType = dyn_cast<RankedTensorType>(ptr.getType())) {
+    auto ptrType = cast<triton::PointerType>(ptrTensorType.getElementType());
+    ptrElemType = ptrType.getPointeeType();
+  } else if (auto tensorPtrType =
+                 dyn_cast<triton::PointerType>(ptr.getType())) {
+    auto tensorType = cast<ShapedType>(tensorPtrType.getPointeeType());
+    ptrElemType = tensorType.getElementType();
+  } else {
+    return emitOpError(
+        "ptr must be either a tensor of pointers or a pointer to tensor");
+  }
+
+  auto cmpTensorType = dyn_cast<RankedTensorType>(cmp.getType());
+  if (!cmpTensorType) {
+    return emitOpError("cmp must be a tensor");
+  }
+  Type cmpElemType = cmpTensorType.getElementType();
+
+  auto valTensorType = dyn_cast<RankedTensorType>(val.getType());
+  if (!valTensorType) {
+    return emitOpError("val must be a tensor");
+  }
+  Type valElemType = valTensorType.getElementType();
+
+  if (ptrElemType != cmpElemType) {
+    return emitOpError("ptr and cmp must have the same element type, got ")
+           << ptrElemType << " and " << cmpElemType;
+  }
+  if (ptrElemType != valElemType) {
+    return emitOpError("ptr and val must have the same element type, got ")
+           << ptrElemType << " and " << valElemType;
+  }
+
+  return success();
 }
 
 LogicalResult GetStructuredStateOp::verify() {

--- a/test/Conversion/TritonToStructured/atomics.mlir
+++ b/test/Conversion/TritonToStructured/atomics.mlir
@@ -1,0 +1,149 @@
+// RUN: triton-shared-opt --triton-to-structured --remove-dead-values --canonicalize %s | FileCheck %s
+
+// Positive test: successfully lower to tts.atomic_rmw and tts.make_tptr
+tt.func public @atomic_add_1d(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+  %c1_i32 = arith.constant 1 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant dense<true> : tensor<16xi1>
+  %cst_0 = arith.constant dense<1.000000e+00> : tensor<16xf32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  scf.for %arg1 = %c0_i32 to %c10_i32 step %c1_i32  : i32 {
+    %3 = tt.atomic_rmw fadd, acq_rel, gpu, %2, %cst_0, %cst : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>, tensor<16xi1>) -> tensor<16xf32>
+  }
+  tt.return
+}
+
+// CHECK-LABEL:   tt.func public @atomic_add_1d(
+// CHECK-SAME:      {{.*}}: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+// CHECK:           %[[TPTR:.*]] = tts.make_tptr {{.*}} to sizes: [16], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<16x!tt.ptr<f32>>
+// CHECK:           scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}}  : i32 {
+// CHECK:             {{.*}} = tts.atomic_rmw fadd, acq_rel, gpu, %[[TPTR]], {{.*}} {static_mask_dims = array<i64>} : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) -> tensor<16xf32>
+// CHECK:           }
+
+
+// Test different op (atomic xchg) to validate we lower the "op" field of the RMW correctly
+tt.func public @atomic_xchg_1d(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+  %c1_i32 = arith.constant 1 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant dense<true> : tensor<16xi1>
+  %cst_0 = arith.constant dense<1.000000e+00> : tensor<16xf32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  scf.for %arg1 = %c0_i32 to %c10_i32 step %c1_i32  : i32 {
+    %3 = tt.atomic_rmw exch, acq_rel, gpu, %2, %cst_0, %cst : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>, tensor<16xi1>) -> tensor<16xf32>
+  }
+  tt.return
+}
+
+// CHECK-LABEL:   tt.func public @atomic_xchg_1d(
+// CHECK-SAME:      {{.*}}: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+// CHECK:           %[[TPTR:.*]] = tts.make_tptr {{.*}} to sizes: [16], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<16x!tt.ptr<f32>>
+// CHECK:           scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}}  : i32 {
+// CHECK:             {{.*}} = tts.atomic_rmw exch, acq_rel, gpu, %[[TPTR]], {{.*}} {static_mask_dims = array<i64>} : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) -> tensor<16xf32>
+// CHECK:           }
+
+
+// 2D case
+tt.func public @atomic_add_2d(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+  %c1_i32 = arith.constant 1 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant dense<true> : tensor<8x16xi1>
+  %cst_0 = arith.constant dense<1.000000e+00> : tensor<8x16xf32>
+  %cst_1 = arith.constant dense<16> : tensor<8x1xi32>
+  %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+  %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %2 = tt.expand_dims %0 {axis = 1 : i32} : tensor<8xi32> -> tensor<8x1xi32>
+  %3 = arith.muli %2, %cst_1 : tensor<8x1xi32>
+  %4 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<8x1x!tt.ptr<f32>>
+  %5 = tt.addptr %4, %3 : tensor<8x1x!tt.ptr<f32>>, tensor<8x1xi32>
+  %6 = tt.expand_dims %1 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+  %7 = tt.broadcast %5 : tensor<8x1x!tt.ptr<f32>> -> tensor<8x16x!tt.ptr<f32>>
+  %8 = tt.broadcast %6 : tensor<1x16xi32> -> tensor<8x16xi32>
+  %9 = tt.addptr %7, %8 : tensor<8x16x!tt.ptr<f32>>, tensor<8x16xi32>
+  scf.for %arg1 = %c0_i32 to %c10_i32 step %c1_i32  : i32 {
+    %10 = tt.atomic_rmw fadd, acq_rel, gpu, %9, %cst_0, %cst : (tensor<8x16x!tt.ptr<f32>>, tensor<8x16xf32>, tensor<8x16xi1>) -> tensor<8x16xf32>
+  }
+  tt.return
+}
+
+// CHECK-LABEL:   tt.func public @atomic_add_2d(
+// CHECK-SAME:      {{.*}}: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+// CHECK:           %[[TPTR:.*]] = tts.make_tptr {{.*}} to sizes: [8, 16], strides: {{\[}}{{.*}}, 1], offsets: [0, 0], shape: [0, 0], order: [] : <f32> to tensor<8x16x!tt.ptr<f32>>
+// CHECK:           scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}}  : i32 {
+// CHECK:             {{.*}} = tts.atomic_rmw fadd, acq_rel, gpu, %[[TPTR]], {{.*}} {static_mask_dims = array<i64>} : (tensor<8x16x!tt.ptr<f32>>, tensor<8x16xf32>) -> tensor<8x16xf32>
+// CHECK:           }
+
+
+// Negative test - can't prove the region is rectangular so shouldn't lower to tts.atomic_rmw
+tt.func public @atomic_add_1d_no_lower(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg1: tensor<16xi32>) attributes {noinline = false} {
+  %c1_i32 = arith.constant 1 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant dense<true> : tensor<16xi1>
+  %cst_0 = arith.constant dense<1.000000e+00> : tensor<16xf32>
+  %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %2 = tt.addptr %1, %arg1 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  scf.for %arg2 = %c0_i32 to %c10_i32 step %c1_i32  : i32 {
+    %3 = tt.atomic_rmw fadd, acq_rel, gpu, %2, %cst_0, %cst : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>, tensor<16xi1>) -> tensor<16xf32>
+  }
+  tt.return
+}
+
+// CHECK-LABEL:   tt.func public @atomic_add_1d_no_lower(
+// CHECK-SAME:      {{.*}}: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+// CHECK-SAME:      {{.*}}: tensor<16xi32>) attributes {noinline = false} {
+// CHECK:           %[[PTR:.*]] = tt.addptr {{.*}}, {{.*}} : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+// CHECK:           scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}}  : i32 {
+// CHECK:             {{.*}} = tt.atomic_rmw fadd, acq_rel, gpu, %[[PTR]], {{.*}}, {{.*}} : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>, tensor<16xi1>) -> tensor<16xf32>
+// CHECK:           }
+
+
+// Back-to-back atomic add - an atomic returns the value that was in memory before the op runs
+// Use the return value in another atomic to make sure that lowering works
+tt.func public @atomic_add_1d_back_to_back(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+  %c1_i32 = arith.constant 1 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant dense<true> : tensor<16xi1>
+  %cst_0 = arith.constant dense<1.000000e-01> : tensor<16xf32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+  %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+  scf.for %arg1 = %c0_i32 to %c10_i32 step %c1_i32  : i32 {
+    %3 = tt.atomic_rmw fadd, acq_rel, gpu, %2, %cst_0, %cst : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>, tensor<16xi1>) -> tensor<16xf32>
+    %4 = tt.atomic_rmw fadd, acq_rel, gpu, %2, %3, %cst : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>, tensor<16xi1>) -> tensor<16xf32>
+  }
+  tt.return
+}
+
+// CHECK-LABEL:   tt.func public @atomic_add_1d_back_to_back(
+// CHECK-SAME:      {{.*}}: !tt.ptr<f32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+// CHECK:           %[[TPTR:.*]] = tts.make_tptr {{.*}} to sizes: [16], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<16x!tt.ptr<f32>>
+// CHECK:           scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}}  : i32 {
+// CHECK:             %[[RETVAL:.*]] = tts.atomic_rmw fadd, acq_rel, gpu, %[[TPTR]], {{.*}} {static_mask_dims = array<i64>} : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) -> tensor<16xf32>
+// CHECK:             {{.*}} = tts.atomic_rmw fadd, acq_rel, gpu, %[[TPTR]], %[[RETVAL]] {static_mask_dims = array<i64>} : (tensor<16x!tt.ptr<f32>>, tensor<16xf32>) -> tensor<16xf32>
+// CHECK:           }
+
+
+// Atomic CAS - uses a different op than RMW
+tt.func public @atomic_cas_1d(%arg0: !tt.ptr<i32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+  %cst_0 = arith.constant dense<0> : tensor<16xi32>
+  %cst_1 = arith.constant dense<1> : tensor<16xi32>
+  %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %1 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+  %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+  %7 = tt.atomic_cas relaxed, gpu, %2, %cst_0, %cst_1 : (tensor<16x!tt.ptr<i32>>, tensor<16xi32>, tensor<16xi32>) -> tensor<16xi32>
+  tt.return
+}
+
+// CHECK-LABEL:   tt.func public @atomic_cas_1d(
+// CHECK-SAME:      {{.*}}: !tt.ptr<i32> {tt.divisibility = 32 : i32}) attributes {noinline = false} {
+// CHECK:           %[[TPTR:.*]] = tts.make_tptr {{.*}} to sizes: [16], strides: [1], offsets: [0], shape: [0], order: [] : <i32> to tensor<16x!tt.ptr<i32>>
+// CHECK:           {{.*}} = tts.atomic_cas relaxed, gpu, %[[TPTR]], {{.*}}, {{.*}} : (tensor<16x!tt.ptr<i32>>, tensor<16xi32>, tensor<16xi32>) -> tensor<16xi32>
+// CHECK:         }


### PR DESCRIPTION
Add structured `tts.atomic_rmw` and `tts.atomic_cas` operations and lower eligible Triton atomics to them from pointer analysis.