### PR TITLE
[TritonArithToLinalg] Lower multi-result tt.reduce to a single linalg reduce

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1225,64 +1225,70 @@ private:
         });
   }
 
-  // Lower a multi-operand / multi-result `tt.reduce` (e.g. a fused
-  // (sum, sum-of-squares) moment reduction emitted by tl.reduce with a tuple
-  // combine_fn) into a single multi-result `linalg.reduce`. This keeps both
-  // sub-reductions in ONE loop nest over the reduction axis instead of forcing
-  // the front-end to emit two independent `tt.reduce`s. The combine body must
-  // contain exactly one supported reduction op per result, each combining the
-  // matching input/accumulator pair (no cross-result data flow), which is the
-  // shape of an element-wise tuple reduction. argmin/argmax-style reductions
-  // (cross-lane tie-breaking) are handled by the dedicated converters and are
-  // not matched here.
+  // Lower an element-wise `tt.reduce` into a single `linalg.reduce`. Handles
+  // both the single-result case and multi-result tuple reductions, keeping
+  // every sub-reduction in ONE loop nest over the reduction axis (so a fused
+  // moment reduction isn't split into two sweeps over the row).
   //
-  // The single-operand path (convertToLinalgReduce) is left untouched; this is
-  // only reached for getNumOperands() > 1.
+  // Matches bodies where result i is an independent, supported reduction of
+  // input i and accumulator i, e.g. a fused (sum, sum-of-squares):
+  //
+  //   %r:2 = "tt.reduce"(%x, %xx) <{axis = 1}> ({
+  //   ^bb0(%in0: f32, %in1: f32, %acc0: f32, %acc1: f32):
+  //     %s0 = arith.addf %in0, %acc0 : f32   // result 0: sum
+  //     %s1 = arith.addf %in1, %acc1 : f32   // result 1: sum of squares
+  //     tt.reduce.return %s0, %s1 : f32, f32
+  //   })
+  //
+  // Bodies with cross-result data flow (e.g. argmin/argmax tie-breaking, where
+  // the index update reads the value operands) do not have this shape and are
+  // rejected here; they are handled by the dedicated ArgMinMax converters.
   LogicalResult
-  convertToMultiResultLinalgReduce(triton::ReduceOp op,
-                                   typename triton::ReduceOp::Adaptor adaptor,
-                                   ConversionPatternRewriter &rewriter) const {
+  convertToLinalgReduce(triton::ReduceOp op,
+                        typename triton::ReduceOp::Adaptor adaptor,
+                        ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     auto sources = adaptor.getOperands();
     const unsigned numInputs = sources.size();
     auto reductionOps = getRedOps(op);
 
-    // Each result needs its own reduction op in the body; require exactly one
-    // per result and that every one is a supported (associative, no-init-skip)
-    // reduction. Bail to the other converters / failure otherwise.
+    // Each result needs exactly one supported reduction op in the body. This
+    // "exactly one op per result" invariant is also what rules out indirect /
+    // cross-result data flow below: any intermediate op (a negate feeding the
+    // accumulator, a select reading another lane's value, ...) would be an
+    // extra body op and push the count past numInputs, failing the match.
     if (reductionOps.size() != numInputs) {
       return rewriter.notifyMatchFailure(
-          op, "multi-result reduce: expected one reduction op per result");
-    }
-    for (Operation *redOp : reductionOps) {
-      if (!isReductionOpSupported(redOp)) {
-        return rewriter.notifyMatchFailure(
-            op, "multi-result reduce: unsupported reduction op in body");
-      }
+          op, "reduce: expected exactly one reduction op per result");
     }
 
-    // Verify each body op combines the i-th input with the i-th accumulator,
-    // i.e. operands come from block args {i, numInputs + i} in some order. This
-    // rejects cross-result combines (e.g. argmax tie-breaking) which must not
-    // be lowered as independent per-result reductions.
+    // Verify result i is produced by reductionOps[i] combining its own
+    // (input_i, accumulator_i) pair, i.e. the terminator yields that op's
+    // result and its operands are block args {i, numInputs + i} in either
+    // order. isReductionOpSupported already guarantees a binary arith op, so
+    // getOperand(0/1) is safe without a separate arity check.
     Block *body = op.getBody();
+    Operation *terminator = body->getTerminator();
     for (unsigned i = 0; i < numInputs; ++i) {
       Operation *redOp = reductionOps[i];
-      if (redOp->getNumOperands() != 2) {
+      if (!isReductionOpSupported(redOp)) {
         return rewriter.notifyMatchFailure(
-            op, "multi-result reduce: reduction op must be binary");
+            op, "reduce: unsupported reduction op in body");
       }
-      auto isExpectedArg = [&](Value v) {
+      auto isArg = [&](Value v, unsigned argNumber) {
         auto arg = dyn_cast<BlockArgument>(v);
         return arg && arg.getOwner() == body &&
-               (arg.getArgNumber() == i ||
-                arg.getArgNumber() == numInputs + i);
+               arg.getArgNumber() == argNumber;
       };
-      if (!isExpectedArg(redOp->getOperand(0)) ||
-          !isExpectedArg(redOp->getOperand(1))) {
+      Value lhs = redOp->getOperand(0), rhs = redOp->getOperand(1);
+      bool combinesOwnPair =
+          (isArg(lhs, i) && isArg(rhs, numInputs + i)) ||
+          (isArg(rhs, i) && isArg(lhs, numInputs + i));
+      if (terminator->getOperand(i) != redOp->getResult(0) ||
+          !combinesOwnPair) {
         return rewriter.notifyMatchFailure(
-            op, "multi-result reduce: result does not independently combine "
-                "its own input/accumulator pair");
+            op, "reduce: result does not independently combine its own "
+                "input/accumulator pair");
       }
     }
 
@@ -1294,15 +1300,19 @@ private:
     // The manual vector-reduce (rank-1) lowering below is single-result only;
     // multi-result tuple reductions over a 1-D input are rare and would need a
     // separate hand-rolled affine lowering. Defer rather than miscompile.
-    if (isVectorReduce) {
+    if (isVectorReduce && numInputs > 1) {
       return rewriter.notifyMatchFailure(
-          op, "multi-result reduce: vector (rank-1) reduce not supported");
+          op, "reduce: multi-result vector (rank-1) reduce not supported");
     }
 
-    // Optionally transpose every input so the reduction axis is dim 0. All
-    // inputs share the same shape/axis, so apply the identical permutation.
+    // For now we are transposing reductions from Triton Shared as an
+    // optimization. This should not be the job of Triton Shared so moving
+    // forward this will be removed. Doing the transpose here lacks a wider
+    // scope of analysis that might indicate that the transpose to a given axis
+    // is not optimal. All inputs share the same shape/axis, so we apply the
+    // identical permutation to every one.
     SmallVector<Value> srcs(sources.begin(), sources.end());
-    if (transposeToRank0 && axis != 0) {
+    if (transposeToRank0 && !isVectorReduce && axis != 0) {
       SmallVector<int32_t> order;
       order.reserve(rank);
       order.push_back(axis);
@@ -1318,10 +1328,12 @@ private:
     }
 
     // Build a per-result init tensor seeded with that reduction's identity,
-    // honoring the f16->f32 accumulation promotion used by the single path.
+    // honoring the f16->f32 accumulation promotion.
     SmallVector<Value> initTensors;
+    SmallVector<Type> constantTypes;
     SmallVector<bool> convertToF32;
     initTensors.reserve(numInputs);
+    constantTypes.reserve(numInputs);
     convertToF32.reserve(numInputs);
     for (unsigned i = 0; i < numInputs; ++i) {
       Operation *rop = reductionOps[i];
@@ -1331,14 +1343,32 @@ private:
       Type constantType = toF32 ? Float32Type::get(rewriter.getContext())
                                 : cast<RankedTensorType>(srcs[i].getType())
                                       .getElementType();
+      constantTypes.push_back(constantType);
       auto accBaseConstOp = getRedBaseConstOp(rewriter, rop, constantType);
-      Value init = tensor::EmptyOp::create(
-          rewriter, loc, cast<RankedTensorType>(resTypeI).getShape(),
-          constantType);
-      initTensors.push_back(
-          linalg::FillOp::create(rewriter, loc, ValueRange{accBaseConstOp},
-                                 ValueRange{init})
-              .result());
+
+      Value initTensor;
+      if (isVectorReduce) {
+        // The affine vectorizer cannot vectorize affine loops generated from
+        // linalg.reduce for the vector reduce case, so we must rewrite the
+        // linalg.reduce to affine loops manually. Here we lower to AllocTensor
+        // directly instead of EmptyOp so that the subsequent pass can recognize
+        // the patterns (EmptyOp is susceptible to being CSE'd away, making it
+        // harder to match the patterns correctly).
+        initTensor = bufferization::AllocTensorOp::create(
+            rewriter, loc, RankedTensorType::get({}, constantType),
+            ValueRange{});
+        initTensor = tensor::InsertOp::create(rewriter, loc, accBaseConstOp,
+                                              initTensor, ValueRange{});
+      } else {
+        Value init = tensor::EmptyOp::create(
+            rewriter, loc, cast<RankedTensorType>(resTypeI).getShape(),
+            constantType);
+        initTensor =
+            linalg::FillOp::create(rewriter, loc, ValueRange{accBaseConstOp},
+                                   ValueRange{init})
+                .result();
+      }
+      initTensors.push_back(initTensor);
     }
 
     // One linalg.reduce, N inputs / N outputs. The combine region applies each
@@ -1360,9 +1390,18 @@ private:
           linalg::YieldOp::create(opBuilder, loc, yields);
         });
 
-    // Truncate any f32-accumulated results back to the original result type.
     SmallVector<Value> finalResults(linalgReduce.getResults().begin(),
                                     linalgReduce.getResults().end());
+
+    // The vector-reduce path reduces to a 0-D tensor; extract the scalar back
+    // out (single-result only, guarded above).
+    if (isVectorReduce) {
+      finalResults[0] = tensor::ExtractOp::create(rewriter, loc,
+                                                  constantTypes[0],
+                                                  finalResults[0]);
+    }
+
+    // Truncate any f32-accumulated results back to the original result type.
     for (unsigned i = 0; i < numInputs; ++i) {
       if (convertToF32[i]) {
         finalResults[i] = arith::TruncFOp::create(
@@ -1371,117 +1410,6 @@ private:
     }
 
     rewriter.replaceOp(op, finalResults);
-    return success();
-  }
-
-  LogicalResult
-  convertToLinalgReduce(triton::ReduceOp op,
-                        typename triton::ReduceOp::Adaptor adaptor,
-                        ConversionPatternRewriter &rewriter) const {
-    auto source = adaptor.getOperands().front();
-    auto sourceType = cast<RankedTensorType>(source.getType());
-    auto elemType = sourceType.getElementType();
-    auto resType = op.getResult().front().getType();
-    auto loc = op.getLoc();
-    auto reductionOps = getRedOps(op);
-
-    // Reduction of arbitrary operations isn't supported because using the first
-    // element across the reduction dimension requires us to iterate over a
-    // subview that skips over each first element.
-    if (reductionOps.size() != 1 ||
-        !isReductionOpSupported(reductionOps.front())) {
-      return rewriter.notifyMatchFailure(
-          op, "Only support lowering reduction with body "
-              "containing 1 max(i/f), addf, ori, or mulf.");
-    }
-
-    auto rop = reductionOps.front();
-    auto axis = op.getAxis();
-    auto rank = sourceType.getRank();
-    auto isVectorReduce = (rank == 1);
-
-    // For now we are transposing reductions from Triton Shared as an
-    // optimization. This should not be the job of Triton Shared so moving
-    // forward this will be removed. Doing the transpose here lacks a wider
-    // scope of analysis that might indicate that the transpose to a given axis
-    // is not optimal.
-    if (transposeToRank0) {
-      // if it is not a vector reduce, we can transpose the source
-      // so that the reduction axis is the first dimension.
-      if (!isVectorReduce && axis != 0) {
-        SmallVector<int32_t> order;
-        order.reserve(rank);
-        order.push_back(axis);
-        for (int i = 0; i < rank; ++i) {
-          if (i != axis) {
-            order.push_back(i);
-          }
-        }
-        source = getTransposedValue(source, op.getLoc(), rewriter, order);
-        axis = 0;
-      }
-    } 
-    // else {
-    //   // preserving old behavior until we remove the transpose entirely.
-    //   if (axis == rank - 1 && !isVectorReduce) {
-    //     source = getTransposedValue(source, op.getLoc(), rewriter);
-    //     axis = rank - 2;
-    //   }
-    // }
-
-    bool convertToF32Precision = requiresF32Conversion(resType, rop);
-
-    auto constantType = convertToF32Precision
-                            ? Float32Type::get(rewriter.getContext())
-                            : elemType;
-
-    auto accBaseConstOp = getRedBaseConstOp(rewriter, rop, constantType);
-    Value initTensor;
-
-    if (isVectorReduce) {
-      // The affine vectorizer cannot vectorize affine loops generated from
-      // linalg.reduce for the vector reduce case, so we must rewrite the
-      // linalg.reduce to affine loops manually. Here we lower to AllocTensor
-      // directly instead of EmptyOp so that the subsequent pass can recognize
-      // the patterns (EmptyOp is susceptible to being CSE'd away, making it
-      // harder to match the patterns correctly).
-      initTensor = bufferization::AllocTensorOp::create(
-          rewriter, loc, RankedTensorType::get({}, constantType), ValueRange{});
-      initTensor = tensor::InsertOp::create(rewriter, loc, accBaseConstOp,
-                                            initTensor, ValueRange{});
-    } else {
-      Value init = tensor::EmptyOp::create(
-          rewriter, loc, cast<RankedTensorType>(resType).getShape(),
-          constantType);
-      initTensor =
-          linalg::FillOp::create(rewriter, loc, ValueRange{accBaseConstOp},
-                                 ValueRange{init})
-              .result();
-    }
-
-    Value finalResult =
-        linalg::ReduceOp::create(
-            rewriter, loc, ValueRange{source}, ValueRange{initTensor},
-            SmallVector<int64_t>{axis},
-            [&](OpBuilder &opBuilder, Location loc, ValueRange inputs) {
-              assert(inputs.size() == 2);
-              Value result = getRedElement(inputs[0], inputs[1], loc, rop,
-                                           opBuilder, convertToF32Precision);
-              linalg::YieldOp::create(opBuilder, loc, result);
-            })
-            .getResult(0);
-
-    if (isVectorReduce) {
-      finalResult =
-          tensor::ExtractOp::create(rewriter, loc, constantType, finalResult);
-    }
-
-    if (convertToF32Precision) {
-      finalResult =
-          arith::TruncFOp::create(rewriter, loc, resType, finalResult);
-    }
-
-    rewriter.replaceOp(op, finalResult);
     return success();
   }
 
@@ -1501,15 +1429,10 @@ public:
            "axis is within "
            "operand's rank");
 
-    // Multi-operand reductions (tuple combine_fn, e.g. fused (sum, sum^2)) are
-    // lowered to a single multi-result linalg.reduce. argmin/argmax are also
-    // multi-operand but are claimed first by their dedicated converters (higher
-    // benefit / matched earlier), so reaching here with >1 operand means an
-    // element-wise tuple reduction.
-    if (adaptor.getOperands().size() > 1) {
-      return convertToMultiResultLinalgReduce(op, adaptor, rewriter);
-    }
-
+    // argmin/argmax are multi-operand but are claimed first by their dedicated
+    // converters (higher benefit / matched earlier). Everything reaching here —
+    // single-result or an element-wise tuple reduction (e.g. fused (sum, sum^2))
+    // — lowers to a single (multi-result) linalg.reduce.
     return convertToLinalgReduce(op, adaptor, rewriter);
   }
 };

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1225,24 +1225,70 @@ private:
         });
   }
 
+  // Per-result bookkeeping produced while building the init tensors below:
+  // the seeded init tensor itself, the element type it was seeded with (the
+  // original element type, or f32 if promoted), and whether that result's
+  // accumulation runs in promoted f32 precision.
+  struct ReduceResultInit {
+    Value initTensor;
+    Type constantType;
+    bool convertToF32;
+  };
+
+  // Build the init tensor for one reduce result, seeded with reductionOp's
+  // identity element and honoring the f16/bf16->f32 accumulation promotion.
+  ReduceResultInit
+  buildReduceResultInit(Operation *reductionOp, Type resultType,
+                        Type srcElemType, bool isVectorReduce, Location loc,
+                        ConversionPatternRewriter &rewriter) const {
+    bool toF32 = requiresF32Conversion(resultType, reductionOp);
+    Type constantType =
+        toF32 ? Float32Type::get(rewriter.getContext()) : srcElemType;
+    auto accBaseConstOp =
+        getRedBaseConstOp(rewriter, reductionOp, constantType);
+
+    Value initTensor;
+    if (isVectorReduce) {
+      // The affine vectorizer cannot vectorize affine loops generated from
+      // linalg.reduce for the vector reduce case, so we must rewrite the
+      // linalg.reduce to affine loops manually. Here we lower to AllocTensor
+      // directly instead of EmptyOp so that the subsequent pass can recognize
+      // the patterns (EmptyOp is susceptible to being CSE'd away, making it
+      // harder to match the patterns correctly).
+      initTensor = bufferization::AllocTensorOp::create(
+          rewriter, loc, RankedTensorType::get({}, constantType), ValueRange{});
+      initTensor = tensor::InsertOp::create(rewriter, loc, accBaseConstOp,
+                                            initTensor, ValueRange{});
+    } else {
+      Value init = tensor::EmptyOp::create(
+          rewriter, loc, cast<RankedTensorType>(resultType).getShape(),
+          constantType);
+      initTensor =
+          linalg::FillOp::create(rewriter, loc, ValueRange{accBaseConstOp},
+                                 ValueRange{init})
+              .result();
+    }
+    return {initTensor, constantType, toF32};
+  }
+
   // Lower an element-wise `tt.reduce` into a single `linalg.reduce`. Handles
   // both the single-result case and multi-result tuple reductions, keeping
-  // every sub-reduction in ONE loop nest over the reduction axis (so a fused
-  // moment reduction isn't split into two sweeps over the row).
+  // every sub-reduction in ONE loop nest over the reduction axis.
   //
   // Matches bodies where result i is an independent, supported reduction of
-  // input i and accumulator i, e.g. a fused (sum, sum-of-squares):
+  // input i and accumulator i:
   //
-  //   %r:2 = "tt.reduce"(%x, %xx) <{axis = 1}> ({
+  //   %r:2 = "tt.reduce"(%x, %y) <{axis = 1}> ({
   //   ^bb0(%in0: f32, %in1: f32, %acc0: f32, %acc1: f32):
-  //     %s0 = arith.addf %in0, %acc0 : f32   // result 0: sum
-  //     %s1 = arith.addf %in1, %acc1 : f32   // result 1: sum of squares
+  //     %s0 = arith.addf %in0, %acc0 : f32
+  //     %s1 = arith.mulf %in1, %acc1 : f32
   //     tt.reduce.return %s0, %s1 : f32, f32
   //   })
   //
-  // Bodies with cross-result data flow (e.g. argmin/argmax tie-breaking, where
-  // the index update reads the value operands) do not have this shape and are
-  // rejected here; they are handled by the dedicated ArgMinMax converters.
+  // Bodies with cross-result data flow (where one result's combine reads
+  // another result's input/accumulator, as in argmin/argmax tie-breaking) do
+  // not have this shape and are rejected here; they are handled by the
+  // dedicated ArgMinMax converters.
   LogicalResult
   convertToLinalgReduce(triton::ReduceOp op,
                         typename triton::ReduceOp::Adaptor adaptor,
@@ -1257,33 +1303,33 @@ private:
     // cross-result data flow below: any intermediate op (a negate feeding the
     // accumulator, a select reading another lane's value, ...) would be an
     // extra body op and push the count past numInputs, failing the match.
-    if (reductionOps.size() != numInputs) {
+    if (reductionOps.size() != numInputs ||
+        !llvm::all_of(reductionOps, [&](Operation *redOp) {
+          return isReductionOpSupported(redOp);
+        })) {
       return rewriter.notifyMatchFailure(
-          op, "reduce: expected exactly one reduction op per result");
+          op, "reduce: expected exactly one supported reduction op per "
+              "result");
     }
 
     // Verify result i is produced by reductionOps[i] combining its own
     // (input_i, accumulator_i) pair, i.e. the terminator yields that op's
     // result and its operands are block args {i, numInputs + i} in either
-    // order. isReductionOpSupported already guarantees a binary arith op, so
-    // getOperand(0/1) is safe without a separate arity check.
+    // order.
     Block *body = op.getBody();
     Operation *terminator = body->getTerminator();
+    auto isBlockArg = [&](Value v, unsigned argNumber) {
+      auto arg = dyn_cast<BlockArgument>(v);
+      return arg && arg.getOwner() == body && arg.getArgNumber() == argNumber;
+    };
     for (unsigned i = 0; i < numInputs; ++i) {
       Operation *redOp = reductionOps[i];
-      if (!isReductionOpSupported(redOp)) {
-        return rewriter.notifyMatchFailure(
-            op, "reduce: unsupported reduction op in body");
-      }
-      auto isArg = [&](Value v, unsigned argNumber) {
-        auto arg = dyn_cast<BlockArgument>(v);
-        return arg && arg.getOwner() == body &&
-               arg.getArgNumber() == argNumber;
-      };
+      // isReductionOpSupported already guarantees a binary arith op, so
+      // getOperand(0/1) is safe without a separate arity check.
       Value lhs = redOp->getOperand(0), rhs = redOp->getOperand(1);
       bool combinesOwnPair =
-          (isArg(lhs, i) && isArg(rhs, numInputs + i)) ||
-          (isArg(rhs, i) && isArg(lhs, numInputs + i));
+          (isBlockArg(lhs, i) && isBlockArg(rhs, numInputs + i)) ||
+          (isBlockArg(rhs, i) && isBlockArg(lhs, numInputs + i));
       if (terminator->getOperand(i) != redOp->getResult(0) ||
           !combinesOwnPair) {
         return rewriter.notifyMatchFailure(
@@ -1292,7 +1338,7 @@ private:
       }
     }
 
-    auto axis = op.getAxis();
+    int64_t axis = op.getAxis();
     auto sourceType = cast<RankedTensorType>(sources.front().getType());
     auto rank = sourceType.getRank();
     auto isVectorReduce = (rank == 1);
@@ -1336,39 +1382,14 @@ private:
     constantTypes.reserve(numInputs);
     convertToF32.reserve(numInputs);
     for (unsigned i = 0; i < numInputs; ++i) {
-      Operation *rop = reductionOps[i];
-      Type resTypeI = op.getResult()[i].getType();
-      bool toF32 = requiresF32Conversion(resTypeI, rop);
-      convertToF32.push_back(toF32);
-      Type constantType = toF32 ? Float32Type::get(rewriter.getContext())
-                                : cast<RankedTensorType>(srcs[i].getType())
-                                      .getElementType();
-      constantTypes.push_back(constantType);
-      auto accBaseConstOp = getRedBaseConstOp(rewriter, rop, constantType);
-
-      Value initTensor;
-      if (isVectorReduce) {
-        // The affine vectorizer cannot vectorize affine loops generated from
-        // linalg.reduce for the vector reduce case, so we must rewrite the
-        // linalg.reduce to affine loops manually. Here we lower to AllocTensor
-        // directly instead of EmptyOp so that the subsequent pass can recognize
-        // the patterns (EmptyOp is susceptible to being CSE'd away, making it
-        // harder to match the patterns correctly).
-        initTensor = bufferization::AllocTensorOp::create(
-            rewriter, loc, RankedTensorType::get({}, constantType),
-            ValueRange{});
-        initTensor = tensor::InsertOp::create(rewriter, loc, accBaseConstOp,
-                                              initTensor, ValueRange{});
-      } else {
-        Value init = tensor::EmptyOp::create(
-            rewriter, loc, cast<RankedTensorType>(resTypeI).getShape(),
-            constantType);
-        initTensor =
-            linalg::FillOp::create(rewriter, loc, ValueRange{accBaseConstOp},
-                                   ValueRange{init})
-                .result();
-      }
-      initTensors.push_back(initTensor);
+      Type srcElemType =
+          cast<RankedTensorType>(srcs[i].getType()).getElementType();
+      ReduceResultInit resultInit =
+          buildReduceResultInit(reductionOps[i], op.getResult()[i].getType(),
+                                srcElemType, isVectorReduce, loc, rewriter);
+      initTensors.push_back(resultInit.initTensor);
+      constantTypes.push_back(resultInit.constantType);
+      convertToF32.push_back(resultInit.convertToF32);
     }
 
     // One linalg.reduce, N inputs / N outputs. The combine region applies each
@@ -1396,9 +1417,8 @@ private:
     // The vector-reduce path reduces to a 0-D tensor; extract the scalar back
     // out (single-result only, guarded above).
     if (isVectorReduce) {
-      finalResults[0] = tensor::ExtractOp::create(rewriter, loc,
-                                                  constantTypes[0],
-                                                  finalResults[0]);
+      finalResults[0] = tensor::ExtractOp::create(
+          rewriter, loc, constantTypes[0], finalResults[0]);
     }
 
     // Truncate any f32-accumulated results back to the original result type.
@@ -1430,9 +1450,9 @@ public:
            "operand's rank");
 
     // argmin/argmax are multi-operand but are claimed first by their dedicated
-    // converters (higher benefit / matched earlier). Everything reaching here —
-    // single-result or an element-wise tuple reduction (e.g. fused (sum, sum^2))
-    // — lowers to a single (multi-result) linalg.reduce.
+    // converters (higher benefit / matched earlier). Everything reaching here
+    // — single-result or a multi-result tuple reduction — lowers to a single
+    // (multi-result) linalg.reduce.
     return convertToLinalgReduce(op, adaptor, rewriter);
   }
 };

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1225,6 +1225,155 @@ private:
         });
   }
 
+  // Lower a multi-operand / multi-result `tt.reduce` (e.g. a fused
+  // (sum, sum-of-squares) moment reduction emitted by tl.reduce with a tuple
+  // combine_fn) into a single multi-result `linalg.reduce`. This keeps both
+  // sub-reductions in ONE loop nest over the reduction axis instead of forcing
+  // the front-end to emit two independent `tt.reduce`s. The combine body must
+  // contain exactly one supported reduction op per result, each combining the
+  // matching input/accumulator pair (no cross-result data flow), which is the
+  // shape of an element-wise tuple reduction. argmin/argmax-style reductions
+  // (cross-lane tie-breaking) are handled by the dedicated converters and are
+  // not matched here.
+  //
+  // The single-operand path (convertToLinalgReduce) is left untouched; this is
+  // only reached for getNumOperands() > 1.
+  LogicalResult
+  convertToMultiResultLinalgReduce(triton::ReduceOp op,
+                                   typename triton::ReduceOp::Adaptor adaptor,
+                                   ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto sources = adaptor.getOperands();
+    const unsigned numInputs = sources.size();
+    auto reductionOps = getRedOps(op);
+
+    // Each result needs its own reduction op in the body; require exactly one
+    // per result and that every one is a supported (associative, no-init-skip)
+    // reduction. Bail to the other converters / failure otherwise.
+    if (reductionOps.size() != numInputs) {
+      return rewriter.notifyMatchFailure(
+          op, "multi-result reduce: expected one reduction op per result");
+    }
+    for (Operation *redOp : reductionOps) {
+      if (!isReductionOpSupported(redOp)) {
+        return rewriter.notifyMatchFailure(
+            op, "multi-result reduce: unsupported reduction op in body");
+      }
+    }
+
+    // Verify each body op combines the i-th input with the i-th accumulator,
+    // i.e. operands come from block args {i, numInputs + i} in some order. This
+    // rejects cross-result combines (e.g. argmax tie-breaking) which must not
+    // be lowered as independent per-result reductions.
+    Block *body = op.getBody();
+    for (unsigned i = 0; i < numInputs; ++i) {
+      Operation *redOp = reductionOps[i];
+      if (redOp->getNumOperands() != 2) {
+        return rewriter.notifyMatchFailure(
+            op, "multi-result reduce: reduction op must be binary");
+      }
+      auto isExpectedArg = [&](Value v) {
+        auto arg = dyn_cast<BlockArgument>(v);
+        return arg && arg.getOwner() == body &&
+               (arg.getArgNumber() == i ||
+                arg.getArgNumber() == numInputs + i);
+      };
+      if (!isExpectedArg(redOp->getOperand(0)) ||
+          !isExpectedArg(redOp->getOperand(1))) {
+        return rewriter.notifyMatchFailure(
+            op, "multi-result reduce: result does not independently combine "
+                "its own input/accumulator pair");
+      }
+    }
+
+    auto axis = op.getAxis();
+    auto sourceType = cast<RankedTensorType>(sources.front().getType());
+    auto rank = sourceType.getRank();
+    auto isVectorReduce = (rank == 1);
+
+    // The manual vector-reduce (rank-1) lowering below is single-result only;
+    // multi-result tuple reductions over a 1-D input are rare and would need a
+    // separate hand-rolled affine lowering. Defer rather than miscompile.
+    if (isVectorReduce) {
+      return rewriter.notifyMatchFailure(
+          op, "multi-result reduce: vector (rank-1) reduce not supported");
+    }
+
+    // Optionally transpose every input so the reduction axis is dim 0. All
+    // inputs share the same shape/axis, so apply the identical permutation.
+    SmallVector<Value> srcs(sources.begin(), sources.end());
+    if (transposeToRank0 && axis != 0) {
+      SmallVector<int32_t> order;
+      order.reserve(rank);
+      order.push_back(axis);
+      for (int i = 0; i < rank; ++i) {
+        if (i != axis) {
+          order.push_back(i);
+        }
+      }
+      for (auto &src : srcs) {
+        src = getTransposedValue(src, loc, rewriter, order);
+      }
+      axis = 0;
+    }
+
+    // Build a per-result init tensor seeded with that reduction's identity,
+    // honoring the f16->f32 accumulation promotion used by the single path.
+    SmallVector<Value> initTensors;
+    SmallVector<bool> convertToF32;
+    initTensors.reserve(numInputs);
+    convertToF32.reserve(numInputs);
+    for (unsigned i = 0; i < numInputs; ++i) {
+      Operation *rop = reductionOps[i];
+      Type resTypeI = op.getResult()[i].getType();
+      bool toF32 = requiresF32Conversion(resTypeI, rop);
+      convertToF32.push_back(toF32);
+      Type constantType = toF32 ? Float32Type::get(rewriter.getContext())
+                                : cast<RankedTensorType>(srcs[i].getType())
+                                      .getElementType();
+      auto accBaseConstOp = getRedBaseConstOp(rewriter, rop, constantType);
+      Value init = tensor::EmptyOp::create(
+          rewriter, loc, cast<RankedTensorType>(resTypeI).getShape(),
+          constantType);
+      initTensors.push_back(
+          linalg::FillOp::create(rewriter, loc, ValueRange{accBaseConstOp},
+                                 ValueRange{init})
+              .result());
+    }
+
+    // One linalg.reduce, N inputs / N outputs. The combine region applies each
+    // result's reduction to (input_i, acc_i) independently — exactly the body
+    // we validated above.
+    auto linalgReduce = linalg::ReduceOp::create(
+        rewriter, loc, srcs, initTensors, SmallVector<int64_t>{axis},
+        [&](OpBuilder &opBuilder, Location loc, ValueRange args) {
+          // args layout: [in_0..in_{N-1}, acc_0..acc_{N-1}].
+          assert(args.size() == 2 * numInputs);
+          SmallVector<Value> yields;
+          yields.reserve(numInputs);
+          for (unsigned i = 0; i < numInputs; ++i) {
+            Value in = args[i];
+            Value acc = args[numInputs + i];
+            yields.push_back(getRedElement(in, acc, loc, reductionOps[i],
+                                           opBuilder, convertToF32[i]));
+          }
+          linalg::YieldOp::create(opBuilder, loc, yields);
+        });
+
+    // Truncate any f32-accumulated results back to the original result type.
+    SmallVector<Value> finalResults(linalgReduce.getResults().begin(),
+                                    linalgReduce.getResults().end());
+    for (unsigned i = 0; i < numInputs; ++i) {
+      if (convertToF32[i]) {
+        finalResults[i] = arith::TruncFOp::create(
+            rewriter, loc, op.getResult()[i].getType(), finalResults[i]);
+      }
+    }
+
+    rewriter.replaceOp(op, finalResults);
+    return success();
+  }
+
   LogicalResult
   convertToLinalgReduce(triton::ReduceOp op,
                         typename triton::ReduceOp::Adaptor adaptor,
@@ -1271,13 +1420,14 @@ private:
         source = getTransposedValue(source, op.getLoc(), rewriter, order);
         axis = 0;
       }
-    } else {
-      // preserving old behavior until we remove the transpose entirely.
-      if (axis == rank - 1 && !isVectorReduce) {
-        source = getTransposedValue(source, op.getLoc(), rewriter);
-        axis = rank - 2;
-      }
-    }
+    } 
+    // else {
+    //   // preserving old behavior until we remove the transpose entirely.
+    //   if (axis == rank - 1 && !isVectorReduce) {
+    //     source = getTransposedValue(source, op.getLoc(), rewriter);
+    //     axis = rank - 2;
+    //   }
+    // }
 
     bool convertToF32Precision = requiresF32Conversion(resType, rop);
 
@@ -1350,6 +1500,15 @@ public:
            "Expected reduction "
            "axis is within "
            "operand's rank");
+
+    // Multi-operand reductions (tuple combine_fn, e.g. fused (sum, sum^2)) are
+    // lowered to a single multi-result linalg.reduce. argmin/argmax are also
+    // multi-operand but are claimed first by their dedicated converters (higher
+    // benefit / matched earlier), so reaching here with >1 operand means an
+    // element-wise tuple reduction.
+    if (adaptor.getOperands().size() > 1) {
+      return convertToMultiResultLinalgReduce(op, adaptor, rewriter);
+    }
 
     return convertToLinalgReduce(op, adaptor, rewriter);
   }

--- a/test/Conversion/TritonArithToLinalg/reduce_multi_result.mlir
+++ b/test/Conversion/TritonArithToLinalg/reduce_multi_result.mlir
@@ -1,0 +1,57 @@
+// Multi-operand / multi-result tt.reduce (e.g. a fused (sum, sum-of-squares)
+// moment reduction emitted by tl.reduce with a tuple combine_fn) must lower to
+// a SINGLE multi-result linalg.reduce that keeps both sub-reductions in one
+// loop nest over the reduction axis. This is the layer-norm single-pass moment
+// optimization; without it the front-end is forced to emit two independent
+// tt.reduce ops (two sweeps over the row).
+//
+// Two configs are exercised:
+//   - @fused_sum_sumsq:    transpose-reduce-to-rank0=false (the config the
+//                          Hexagon experimental pipeline runs with) -> the
+//                          reduce keeps dimensions = [1].
+//   - @fused_sum_sumsq_t:  transpose-reduce-to-rank0=true (pass default) ->
+//                          BOTH inputs are transposed with the same
+//                          permutation and the reduce runs on dimensions = [0].
+
+// RUN: triton-shared-opt --triton-arith-to-linalg="transpose-reduce-to-rank0=false" %s | FileCheck %s --check-prefix=NOTRANS
+// RUN: triton-shared-opt --triton-arith-to-linalg="transpose-reduce-to-rank0=true" %s | FileCheck %s --check-prefix=TRANS
+
+module {
+  tt.func public @fused_sum_sumsq(%x: tensor<32x512xf32>) -> (tensor<32xf32>, tensor<32xf32>) {
+    %xx = arith.mulf %x, %x : tensor<32x512xf32>
+    %red:2 = "tt.reduce"(%x, %xx) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+      %s0 = arith.addf %a0, %b0 : f32
+      %s1 = arith.addf %a1, %b1 : f32
+      tt.reduce.return %s0, %s1 : f32, f32
+    }) : (tensor<32x512xf32>, tensor<32x512xf32>) -> (tensor<32xf32>, tensor<32xf32>)
+    tt.return %red#0, %red#1 : tensor<32xf32>, tensor<32xf32>
+  }
+}
+
+// One multi-result linalg.reduce, no transpose, reducing the innermost dim.
+// NOTRANS-LABEL:   func.func @fused_sum_sumsq(
+// NOTRANS:           %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// NOTRANS:           %[[XX:.*]] = linalg.generic
+// NOTRANS:           %[[FILL0:.*]] = linalg.fill ins(%[[CST]] : f32) outs({{.*}}) -> tensor<32xf32>
+// NOTRANS:           %[[FILL1:.*]] = linalg.fill ins(%[[CST]] : f32) outs({{.*}}) -> tensor<32xf32>
+// NOTRANS:           %[[RED:.*]]:2 = linalg.reduce ins(%[[ARG0:.*]], %[[XX]] : tensor<32x512xf32>, tensor<32x512xf32>) outs(%[[FILL0]], %[[FILL1]] : tensor<32xf32>, tensor<32xf32>) dimensions = [1]
+// NOTRANS:             (%[[IN0:.*]]: f32, %[[IN1:.*]]: f32, %[[INIT0:.*]]: f32, %[[INIT1:.*]]: f32) {
+// NOTRANS:               %[[A0:.*]] = arith.addf %[[IN0]], %[[INIT0]] : f32
+// NOTRANS:               %[[A1:.*]] = arith.addf %[[IN1]], %[[INIT1]] : f32
+// NOTRANS:               linalg.yield %[[A0]], %[[A1]] : f32, f32
+// NOTRANS:             }
+// NOTRANS:           return %[[RED]]#0, %[[RED]]#1 : tensor<32xf32>, tensor<32xf32>
+
+// Both inputs are transposed with the same permutation, then reduced on dim 0.
+// TRANS-LABEL:   func.func @fused_sum_sumsq(
+// TRANS:           %[[XX:.*]] = linalg.generic
+// TRANS:           %[[T0:.*]] = linalg.transpose ins(%[[ARG0:.*]] : tensor<32x512xf32>) outs({{.*}} : tensor<512x32xf32>) permutation = [1, 0]
+// TRANS:           %[[T1:.*]] = linalg.transpose ins(%[[XX]] : tensor<32x512xf32>) outs({{.*}} : tensor<512x32xf32>) permutation = [1, 0]
+// TRANS:           %[[RED:.*]]:2 = linalg.reduce ins(%[[T0]], %[[T1]] : tensor<512x32xf32>, tensor<512x32xf32>) outs({{.*}}, {{.*}} : tensor<32xf32>, tensor<32xf32>) dimensions = [0]
+// TRANS:             (%[[IN0:.*]]: f32, %[[IN1:.*]]: f32, %[[INIT0:.*]]: f32, %[[INIT1:.*]]: f32) {
+// TRANS:               %[[A0:.*]] = arith.addf %[[IN0]], %[[INIT0]] : f32
+// TRANS:               %[[A1:.*]] = arith.addf %[[IN1]], %[[INIT1]] : f32
+// TRANS:               linalg.yield %[[A0]], %[[A1]] : f32, f32
+// TRANS:             }
+// TRANS:           return %[[RED]]#0, %[[RED]]#1 : tensor<32xf32>, tensor<32xf32>

--- a/test/Conversion/TritonArithToLinalg/reduce_multi_result.mlir
+++ b/test/Conversion/TritonArithToLinalg/reduce_multi_result.mlir
@@ -1,12 +1,10 @@
-// Multi-operand / multi-result tt.reduce (e.g. a fused (sum, sum-of-squares)
-// moment reduction emitted by tl.reduce with a tuple combine_fn) must lower to
-// a SINGLE multi-result linalg.reduce that keeps both sub-reductions in one
-// loop nest over the reduction axis.
+// Multi-operand / multi-result tt.reduce must lower to a SINGLE multi-result
+// linalg.reduce that keeps both sub-reductions in one loop nest over the
+// reduction axis.
 //
 // Two configs are exercised:
-//   - @fused_sum_sumsq:    transpose-reduce-to-rank0=false (the config the
-//                          Hexagon experimental pipeline runs with) -> the
-//                          reduce keeps dimensions = [1].
+//   - @fused_sum_sumsq:    transpose-reduce-to-rank0=false -> the reduce
+//                          keeps dimensions = [1].
 //   - @fused_sum_sumsq_t:  transpose-reduce-to-rank0=true (pass default) ->
 //                          BOTH inputs are transposed with the same
 //                          permutation and the reduce runs on dimensions = [0].

--- a/test/Conversion/TritonArithToLinalg/reduce_multi_result.mlir
+++ b/test/Conversion/TritonArithToLinalg/reduce_multi_result.mlir
@@ -1,9 +1,7 @@
 // Multi-operand / multi-result tt.reduce (e.g. a fused (sum, sum-of-squares)
 // moment reduction emitted by tl.reduce with a tuple combine_fn) must lower to
 // a SINGLE multi-result linalg.reduce that keeps both sub-reductions in one
-// loop nest over the reduction axis. This is the layer-norm single-pass moment
-// optimization; without it the front-end is forced to emit two independent
-// tt.reduce ops (two sweeps over the row).
+// loop nest over the reduction axis.
 //
 // Two configs are exercised:
 //   - @fused_sum_sumsq:    transpose-reduce-to-rank0=false (the config the

--- a/test/Conversion/TritonArithToLinalg/reduce_multi_result_mixed_ops.mlir
+++ b/test/Conversion/TritonArithToLinalg/reduce_multi_result_mixed_ops.mlir
@@ -1,0 +1,33 @@
+// Multi-result `tt.reduce` where each result uses a DIFFERENT (but
+// independently supported) reduction op — result 0 is a sum, result 1 is a
+// product. This exercises that the per-result reductionOps[i] is threaded
+// through correctly (distinct identity constants, distinct combine ops in
+// the shared linalg.reduce region) rather than assuming all results share
+// one op.
+
+// RUN: triton-shared-opt --triton-arith-to-linalg="transpose-reduce-to-rank0=false" %s | FileCheck %s
+
+module {
+  tt.func public @mixed_sum_prod(%x: tensor<32x512xf32>, %y: tensor<32x512xf32>) -> (tensor<32xf32>, tensor<32xf32>) {
+    %red:2 = "tt.reduce"(%x, %y) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+      %s0 = arith.addf %a0, %b0 : f32
+      %s1 = arith.mulf %a1, %b1 : f32
+      tt.reduce.return %s0, %s1 : f32, f32
+    }) : (tensor<32x512xf32>, tensor<32x512xf32>) -> (tensor<32xf32>, tensor<32xf32>)
+    tt.return %red#0, %red#1 : tensor<32xf32>, tensor<32xf32>
+  }
+}
+
+// CHECK-LABEL:   func.func @mixed_sum_prod(
+// CHECK:           %[[ONE:.*]] = arith.constant 1.000000e+00 : f32
+// CHECK:           %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[FILL0:.*]] = linalg.fill ins(%[[ZERO]] : f32) outs({{.*}}) -> tensor<32xf32>
+// CHECK:           %[[FILL1:.*]] = linalg.fill ins(%[[ONE]] : f32) outs({{.*}}) -> tensor<32xf32>
+// CHECK:           %[[RED:.*]]:2 = linalg.reduce ins(%[[ARG0:.*]], %[[ARG1:.*]] : tensor<32x512xf32>, tensor<32x512xf32>) outs(%[[FILL0]], %[[FILL1]] : tensor<32xf32>, tensor<32xf32>) dimensions = [1]
+// CHECK:             (%[[IN0:.*]]: f32, %[[IN1:.*]]: f32, %[[INIT0:.*]]: f32, %[[INIT1:.*]]: f32) {
+// CHECK:               %[[A0:.*]] = arith.addf %[[IN0]], %[[INIT0]] : f32
+// CHECK:               %[[A1:.*]] = arith.mulf %[[IN1]], %[[INIT1]] : f32
+// CHECK:               linalg.yield %[[A0]], %[[A1]] : f32, f32
+// CHECK:             }
+// CHECK:           return %[[RED]]#0, %[[RED]]#1 : tensor<32xf32>, tensor<32xf32>

--- a/test/Conversion/TritonArithToLinalg/reduce_multi_result_negative.mlir
+++ b/test/Conversion/TritonArithToLinalg/reduce_multi_result_negative.mlir
@@ -1,0 +1,78 @@
+// Negative cases for ReduceConverter::convertToLinalgReduce: bodies that must
+// be rejected and left as `tt.reduce` (unconverted) rather than lowered to
+// linalg.reduce, because they don't fit the "each result independently
+// combines its own (input_i, accumulator_i) pair" shape the converter
+// requires.
+
+// RUN: triton-shared-opt --triton-arith-to-linalg --split-input-file %s | FileCheck %s
+
+// An unsupported binary op (subf isn't associative/commutative in a way the
+// converter recognizes as a reduction) must not be converted.
+module {
+  tt.func public @unsupported_op(%x: tensor<32x512xf32>) -> tensor<32xf32> {
+    %red = "tt.reduce"(%x) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %b0: f32):
+      %s0 = arith.subf %a0, %b0 : f32
+      tt.reduce.return %s0 : f32
+    }) : (tensor<32x512xf32>) -> tensor<32xf32>
+    tt.return %red : tensor<32xf32>
+  }
+}
+
+// CHECK-LABEL:   func.func @unsupported_op(
+// CHECK:           %[[RED:.*]] = "tt.reduce"(%[[ARG0:.*]])
+// CHECK:           ^bb0(%[[A0:.*]]: f32, %[[B0:.*]]: f32):
+// CHECK:             %[[S0:.*]] = arith.subf %[[A0]], %[[B0]] : f32
+// CHECK:             tt.reduce.return %[[S0]] : f32
+// CHECK:           return %[[RED]] : tensor<32xf32>
+
+// -----
+
+// Cross-result data flow: result 0 combines (input_1, acc_0) instead of its
+// own (input_0, acc_0) pair. This shape is what argmin/argmax tie-breaking
+// bodies also have, and must be left for the dedicated ArgMinMax converters
+// (which don't match this particular body either, so it stays unconverted).
+module {
+  tt.func public @cross_result_dataflow(%x: tensor<32x512xf32>, %y: tensor<32x512xf32>) -> (tensor<32xf32>, tensor<32xf32>) {
+    %red:2 = "tt.reduce"(%x, %y) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+      %s0 = arith.addf %a1, %b0 : f32
+      %s1 = arith.addf %a0, %b1 : f32
+      tt.reduce.return %s0, %s1 : f32, f32
+    }) : (tensor<32x512xf32>, tensor<32x512xf32>) -> (tensor<32xf32>, tensor<32xf32>)
+    tt.return %red#0, %red#1 : tensor<32xf32>, tensor<32xf32>
+  }
+}
+
+// CHECK-LABEL:   func.func @cross_result_dataflow(
+// CHECK:           %[[RED:.*]]:2 = "tt.reduce"(%[[ARG0:.*]], %[[ARG1:.*]])
+// CHECK:           ^bb0(%[[A0:.*]]: f32, %[[A1:.*]]: f32, %[[B0:.*]]: f32, %[[B1:.*]]: f32):
+// CHECK:             %[[S0:.*]] = arith.addf %[[A1]], %[[B0]] : f32
+// CHECK:             %[[S1:.*]] = arith.addf %[[A0]], %[[B1]] : f32
+// CHECK:             tt.reduce.return %[[S0]], %[[S1]] : f32, f32
+// CHECK:           return %[[RED]]#0, %[[RED]]#1 : tensor<32xf32>, tensor<32xf32>
+
+// -----
+
+// Multi-result reduce over a rank-1 (vector) input: the manual affine
+// lowering used for vector reduces is single-result only, so this must be
+// deferred rather than lowered.
+module {
+  tt.func public @vector_multi_result(%x: tensor<512xf32>, %y: tensor<512xf32>) -> (f32, f32) {
+    %red:2 = "tt.reduce"(%x, %y) <{axis = 0 : i32}> ({
+    ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+      %s0 = arith.addf %a0, %b0 : f32
+      %s1 = arith.addf %a1, %b1 : f32
+      tt.reduce.return %s0, %s1 : f32, f32
+    }) : (tensor<512xf32>, tensor<512xf32>) -> (f32, f32)
+    tt.return %red#0, %red#1 : f32, f32
+  }
+}
+
+// CHECK-LABEL:   func.func @vector_multi_result(
+// CHECK:           %[[RED:.*]]:2 = "tt.reduce"(%[[ARG0:.*]], %[[ARG1:.*]])
+// CHECK:           ^bb0(%[[A0:.*]]: f32, %[[A1:.*]]: f32, %[[B0:.*]]: f32, %[[B1:.*]]: f32):
+// CHECK:             %[[S0:.*]] = arith.addf %[[A0]], %[[B0]] : f32
+// CHECK:             %[[S1:.*]] = arith.addf %[[A1]], %[[B1]] : f32
+// CHECK:             tt.reduce.return %[[S0]], %[[S1]] : f32, f32
+// CHECK:           return %[[RED]]#0, %[[RED]]#1 : f32, f32

--- a/test/Conversion/TritonArithToLinalg/reduce_notrans_axis_last.mlir
+++ b/test/Conversion/TritonArithToLinalg/reduce_notrans_axis_last.mlir
@@ -1,0 +1,32 @@
+// Single-result `tt.reduce` on the innermost axis under
+// transpose-reduce-to-rank0=false: no transpose is applied and
+// linalg.reduce runs directly on the original (non-transposed) axis. This
+// locks in the current behavior (rather than the legacy transpose-to-
+// rank0-minus-1 lowering this pass used before multi-result support was
+// added) so a future refactor of the transpose logic can't silently regress
+// it. See reduce_multi_result.mlir for the same axis under
+// transpose-reduce-to-rank0=true.
+
+// RUN: triton-shared-opt --triton-arith-to-linalg="transpose-reduce-to-rank0=false" %s | FileCheck %s
+
+module {
+  tt.func public @sum_axis_last(%x: tensor<32x512xf32>) -> tensor<32xf32> {
+    %red = "tt.reduce"(%x) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %b0: f32):
+      %s0 = arith.addf %a0, %b0 : f32
+      tt.reduce.return %s0 : f32
+    }) : (tensor<32x512xf32>) -> tensor<32xf32>
+    tt.return %red : tensor<32xf32>
+  }
+}
+
+// CHECK-LABEL:   func.func @sum_axis_last(
+// CHECK:           %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-NOT:       linalg.transpose
+// CHECK:           %[[FILL:.*]] = linalg.fill ins(%[[CST]] : f32) outs({{.*}}) -> tensor<32xf32>
+// CHECK:           %[[RED:.*]] = linalg.reduce ins(%[[ARG0:.*]] : tensor<32x512xf32>) outs(%[[FILL]] : tensor<32xf32>) dimensions = [1]
+// CHECK:             (%[[IN:.*]]: f32, %[[INIT:.*]]: f32) {
+// CHECK:               %[[A:.*]] = arith.addf %[[IN]], %[[INIT]] : f32
+// CHECK:               linalg.yield %[[A]] : f32
+// CHECK:             }
+// CHECK:           return %[[RED]] : tensor<32xf32>


### PR DESCRIPTION
**Problem**:
When we specify multiple outputs in a tt.reduce then the op was not being lowered.

**Solution**:
Adding support for multi-result lowering that converts an N-input/N-result `tt.reduce` into a single N-result linalg.reduce, preserving the existing per-result f32 accumulation promotion. It is guarded to require one supported reduction op per result combining its own input/accumulator pair, so argmin/argmax-style bodies still lower via their dedicated converters, and the rank-1 vector-reduce case is deferred.

Also, refactored the single-result reduction lowering along with the new workflow to reduce duplication, and removed the transpose from being generated in certain single-reduction scenarios.

**Testing**:
Adds lit tests covering a two-result reduce scenarios along with the guard to enforce the transpose reduction change.