### PR TITLE
Add WRAP_1D path to rewriteSplitPtr for circular-buffer loads (ptr[i % N])

### DIFF
--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -44,6 +44,7 @@ using namespace mlir;
 
 static const std::string WRAP_SIDE_BY_SIDE = "wrap_side_by_side";
 static const std::string WRAP_STACKED = "wrap_stacked";
+static const std::string WRAP_1D = "wrap_1d";
 
 static memref::SubViewOp getSubview(int rank, ArrayRef<OpFoldResult> dims,
                                     Value source, Location loc, OpBuilder &b) {
@@ -139,6 +140,29 @@ static OpFoldResult accumulateTargetOffset(Location loc,
     targetOffset = addOFRs(targetOffset, offset, loc, b);
   }
   return targetOffset;
+}
+
+// Shared split-pointer arithmetic for all circular-buffer wrap cases.
+// Returns {xAddr, d1, d2} where:
+//   xAddr = targetOffset % modN        (start position within the wrapping
+//           period, in ADDRESS units; callers use it to derive their own
+//           chunk offsets — see below)
+//   xElem = xAddr / stride             (same position in ELEMENT units)
+//   elemM = modN / stride              (modulo period, in elements)
+//   d1    = min(xElem + blockSz, elemM) - xElem  (elements before boundary)
+//   d2    = blockSz - d1                          (elements after wrap, may 0)
+//
+static std::tuple<Value, Value, Value>
+computeWrapSizes(Value targetOffset, Value modN, Value blockSz, Value stride,
+                 Location loc, OpBuilder &rewriter) {
+  Value xAddr = arith::RemSIOp::create(rewriter, loc, targetOffset, modN);
+  Value xElem = arith::DivSIOp::create(rewriter, loc, xAddr, stride);
+  Value elemM = arith::DivSIOp::create(rewriter, loc, modN, stride);
+  Value nextOff = arith::AddIOp::create(rewriter, loc, xElem, blockSz);
+  Value clampedOff = arith::MinSIOp::create(rewriter, loc, nextOff, elemM);
+  Value d1 = arith::SubIOp::create(rewriter, loc, clampedOff, xElem);
+  Value d2 = arith::SubIOp::create(rewriter, loc, blockSz, d1);
+  return {xAddr, d1, d2};
 }
 
 static Value rewriteGatherScatterPtrElement(
@@ -299,29 +323,29 @@ private:
 
     Value modN = ofrToIndexValue(op.getMixedShape()[1], loc, rewriter);
 
-    Value x = arith::RemSIOp::create(rewriter, loc, targetOffset, modN);
-    Value y = arith::SubIOp::create(rewriter, loc, targetOffset, x);
-
     SmallVector<Value> strideVals =
         ofrsToIndexValues(op.getMixedStrides(), loc, rewriter);
 
-    // First chunk
-    Value nextOffset = arith::AddIOp::create(rewriter, loc, x, colSize);
-    Value clampedOffset =
-        arith::MinSIOp::create(rewriter, loc, nextOffset, modN);
-    Value d1 = arith::SubIOp::create(rewriter, loc, clampedOffset, x);
+    // The wrapping dimension is the column (dim 1); its stride scales both
+    // targetOffset's contribution and modN (see computeWrapSizes doc comment).
+    // computeWrapSizes returns only the split sizes + xAddr; the 2D chunk
+    // offsets are the plain targetOffset (chunk1) and the row base
+    // targetOffset - xAddr (chunk2), which are always valid for the supported
+    // single-period side-by-side case (multi-period is unsupported here).
+    auto [xAddr, d1, d2] = computeWrapSizes(
+        targetOffset, modN, colSize, strideVals[1], loc, rewriter);
+    Value rowBase = arith::SubIOp::create(rewriter, loc, targetOffset, xAddr);
     SmallVector<Value> sizes1{rowSize, d1};
 
     auto cast1 = memref::ReinterpretCastOp::create(
         rewriter, loc, resultType, adaptor.getBase(), targetOffset, sizes1,
         strideVals);
 
-    // Second chunk
-    Value d2 = arith::SubIOp::create(rewriter, loc, colSize, d1);
     SmallVector<Value> sizes2{rowSize, d2};
 
     auto cast2 = memref::ReinterpretCastOp::create(
-        rewriter, loc, resultType, adaptor.getBase(), y, sizes2, strideVals);
+        rewriter, loc, resultType, adaptor.getBase(), rowBase, sizes2,
+        strideVals);
 
     return {cast1, cast2};
   }
@@ -456,33 +480,119 @@ private:
     return {cast1, cast2};
   }
 
+  // Handles 1D circular-buffer wrap-around: ptr[stride * (i % N)] where the
+  // tile [startOffset, startOffset+XBLOCK) may straddle the modulo boundary.
+  //
+  // `stride` is the element stride of the wrapping dimension (usually 1, but
+  // e.g. 3 for an index of the form `y0 + 3*(x1 % 32)` — see
+  // PtrAnalysis::mulState, which scales offset/stride/shape together when a
+  // modulo'd index is multiplied by a constant). See computeWrapSizes for 
+  // the element-unit offset/size math this now shares with the 2D 
+  // side-by-side case.
+  //
+  //   elemOff = startOffset / stride  (start position, in elements)
+  //   x       = elemOff % N            (real column the tile starts at —
+  //             equal to elemOff only when elemOff < N; a later tile can
+  //             start on or past a wrap boundary, elemOff >= N, in which
+  //             case x < elemOff and `startOffset` is NOT a valid chunk1
+  //             address — see computeWrapSizes for why offset1 must be
+  //             re-derived from x, not reused as raw startOffset)
+  //   d1      = min(x + XBLOCK, N) - x  (elements before wrap)
+  //   d2      = XBLOCK - d1              (elements after wrap, from 0)
+  //
+  //   chunk1: base[offset1 .. offset1 + d1*stride)   stride `stride`
+  //   chunk2: base[offset2 .. offset2 + d2*stride)    stride `stride`
+  //           (i.e. from the start of the period in flat memory)
+  //
+  // When d2 == 0 (no wrap, common case) chunk2 is a zero-size memref; the
+  // downstream CopyOp over it is a no-op.
+  std::pair<memref::ReinterpretCastOp, memref::ReinterpretCastOp>
+  create1DCastOps(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const {
+    auto loc = op->getLoc();
+
+    auto resultType = getResultMemrefType(
+        op, /* offset */ ShapedType::kDynamic,
+        /* staticStrides */ SmallVector<int64_t>{ShapedType::kDynamic},
+        /* resultShape */ SmallVector<int64_t>{ShapedType::kDynamic});
+
+    auto targetOffset = ofrToIndexValue(
+        accumulateTargetOffset(op.getLoc(), op.getMixedOffsets(), rewriter),
+        loc, rewriter);
+
+    // N = modulo bound stored in shape[0] by PtrAnalysis::visitOperandRem
+    // (scaled by stride if the modulo'd index was also multiplied — see
+    // PtrAnalysis::mulState).
+    Value modN = ofrToIndexValue(op.getMixedShape()[0], loc, rewriter);
+
+    Value blockSz = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(op.getSizes()[0]));
+
+    Value stride = ofrToIndexValue(op.getMixedStrides()[0], loc, rewriter);
+
+    auto [xAddr, d1, d2] =
+        computeWrapSizes(targetOffset, modN, blockSz, stride, loc, rewriter);
+
+    // 1D has no other dimension, so the "rest" offset (contribution of dims
+    // besides the wrapping one) is 0: chunk1 starts at the real in-buffer
+    // address xAddr = targetOffset % modN (which correctly wraps a tile that
+    // starts a whole period past the buffer start — where raw targetOffset
+    // would read out of bounds), and chunk2 restarts at the period base 0.
+    Value zero =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
+
+    // chunk1: [xAddr, xAddr + d1*stride)
+    SmallVector<Value> sizes1{d1};
+    SmallVector<Value> strides1{stride};
+    auto cast1 = memref::ReinterpretCastOp::create(
+        rewriter, loc, resultType, adaptor.getBase(),
+        xAddr, sizes1, strides1);
+
+    // chunk2: [0, 0 + d2*stride)
+    SmallVector<Value> sizes2{d2};
+    auto cast2 = memref::ReinterpretCastOp::create(
+        rewriter, loc, resultType, adaptor.getBase(),
+        zero, sizes2, strides1);
+
+    return {cast1, cast2};
+  }
+
   LogicalResult rewriteSplitPtr(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     auto parentShape = op.getStaticShape();
-    assert(parentShape.size() == 2 &&
-           "Only support split pointer for 2D tensors only");
     SmallVector<Value> casts;
     StringRef wrapType;
 
-    // For split pointers, a split dimension is either a dynamic or a non-zero
-    // value. The other dimension must be zero.
-    auto isSplitDimension = [](int64_t dim) {
-      return dim == ShapedType::kDynamic || dim != 0;
-    };
-
-    if (isSplitDimension(parentShape[0])) {
-      // Stacked case
-      assert(parentShape[1] == 0);
-      auto [cast1, cast2] = createStackedCastOps(op, adaptor, rewriter);
+    if (parentShape.size() == 1) {
+      // 1D circular-buffer wrap-around: ptr[i % N]
+      // shape[0] carries N (set by PtrAnalysis::visitOperandRem for rank-1).
+      auto [cast1, cast2] = create1DCastOps(op, adaptor, rewriter);
       casts = {cast1.getResult(), cast2.getResult()};
-      wrapType = WRAP_STACKED;
-    } else if (isSplitDimension(parentShape[1])) {
-      assert(parentShape[0] == 0);
-      auto [cast1, cast2] = createSideBySideCastOps(op, adaptor, rewriter);
-      casts = {cast1.getResult(), cast2.getResult()};
-      wrapType = WRAP_SIDE_BY_SIDE;
+      wrapType = WRAP_1D;
     } else {
-      llvm_unreachable("Unexpected split pointer shape");
+      assert(parentShape.size() == 2 &&
+             "Only support split pointer for 1D and 2D tensors");
+
+      // For split pointers, a split dimension is either a dynamic or a non-zero
+      // value. The other dimension must be zero.
+      auto isSplitDimension = [](int64_t dim) {
+        return dim == ShapedType::kDynamic || dim != 0;
+      };
+
+      if (isSplitDimension(parentShape[0])) {
+        // Stacked case
+        assert(parentShape[1] == 0);
+        auto [cast1, cast2] = createStackedCastOps(op, adaptor, rewriter);
+        casts = {cast1.getResult(), cast2.getResult()};
+        wrapType = WRAP_STACKED;
+      } else if (isSplitDimension(parentShape[1])) {
+        assert(parentShape[0] == 0);
+        auto [cast1, cast2] = createSideBySideCastOps(op, adaptor, rewriter);
+        casts = {cast1.getResult(), cast2.getResult()};
+        wrapType = WRAP_SIDE_BY_SIDE;
+      } else {
+        llvm_unreachable("Unexpected split pointer shape");
+      }
     }
 
     auto combinedCast = UnrealizedConversionCastOp::create(
@@ -643,6 +753,34 @@ private:
     memref::CopyOp::create(rewriter, loc, block2, block2Dst);
   }
 
+  // 1D wrap copy: block1 = [offset1, offset1+d1), fills dst[0..d1).
+  //               block2 = wrapped part [offset2, offset2+d2), fills dst[d1..XBLOCK).
+  // When d2 == 0 (no wrap) block2 has size 0 and the second CopyOp is a no-op.
+  void create1DCopies(Value block1, Value block2, Value dst, Location loc,
+                      ConversionPatternRewriter &rewriter) const {
+    auto zero =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
+    auto one =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
+
+    Value d1 = memref::DimOp::create(rewriter, loc, block1, 0);
+    Value d2 = memref::DimOp::create(rewriter, loc, block2, 0);
+
+    // dst[0 : d1]  <- block1
+    auto block1Dst = memref::SubViewOp::create(rewriter, loc, dst,
+                                               ValueRange{zero},
+                                               ValueRange{d1},
+                                               ValueRange{one});
+    // dst[d1 : d1 + d2]  <- block2
+    auto block2Dst = memref::SubViewOp::create(rewriter, loc, dst,
+                                               ValueRange{d1},
+                                               ValueRange{d2},
+                                               ValueRange{one});
+
+    memref::CopyOp::create(rewriter, loc, block1, block1Dst);
+    memref::CopyOp::create(rewriter, loc, block2, block2Dst);
+  }
+
   memref::SubViewOp createSubview(Value src, ArrayRef<OpFoldResult> offsets,
                                   ArrayRef<OpFoldResult> sizes,
                                   ArrayRef<OpFoldResult> strides, Location loc,
@@ -695,6 +833,25 @@ private:
     return {sv1, sv2};
   }
 
+  // 1D masked subviews: each chunk is already sized to d1/d2 by the cast ops,
+  // so we read the actual dim and clip to the mask dimension.
+  std::pair<memref::SubViewOp, memref::SubViewOp>
+  get1DSubviews(ArrayRef<OpFoldResult> dims, Value block1, Value block2,
+                Location loc, ConversionPatternRewriter &rewriter) const {
+    // dims[0] is the mask size for the whole 1D block.
+    // chunk1 contributes min(d1, maskSize) elements; chunk2 the remainder.
+    // We use the actual sizes already baked into the ReinterpretCastOps (d1/d2)
+    // directly, clipped by the mask dimension via SubViewOp.
+    OpFoldResult d1 = memref::DimOp::create(rewriter, loc, block1, 0).getResult();
+    OpFoldResult d2 = memref::DimOp::create(rewriter, loc, block2, 0).getResult();
+
+    SmallVector<OpFoldResult> offsets{rewriter.getIndexAttr(0)};
+    SmallVector<OpFoldResult> strides{rewriter.getIndexAttr(1)};
+    auto sv1 = createSubview(block1, offsets, {d1}, strides, loc, rewriter);
+    auto sv2 = createSubview(block2, offsets, {d2}, strides, loc, rewriter);
+    return {sv1, sv2};
+  }
+
   LogicalResult
   rewriteStructuredLoad(tts::LoadOp op, OpAdaptor adaptor,
                         ConversionPatternRewriter &rewriter) const {
@@ -715,7 +872,8 @@ private:
 
     auto ptrDefiningOp = ptr.getDefiningOp();
     if (ptrDefiningOp->hasAttr(WRAP_SIDE_BY_SIDE) ||
-        ptrDefiningOp->hasAttr(WRAP_STACKED)) {
+        ptrDefiningOp->hasAttr(WRAP_STACKED) ||
+        ptrDefiningOp->hasAttr(WRAP_1D)) {
 
       auto unrealizedCast = cast<UnrealizedConversionCastOp>(ptrDefiningOp);
       auto memrefs = unrealizedCast.getOperands();
@@ -727,6 +885,8 @@ private:
         createSideBySideCopies(block1, block2, alloc, loc, rewriter);
       } else if (unrealizedCast->hasAttr(WRAP_STACKED)) {
         createStackedCopies(block1, block2, alloc, loc, rewriter);
+      } else if (unrealizedCast->hasAttr(WRAP_1D)) {
+        create1DCopies(block1, block2, alloc, loc, rewriter);
       } else {
         llvm_unreachable("unexpected wraparound type");
       }
@@ -765,7 +925,8 @@ private:
 
     auto ptrDefiningOp = ptr.getDefiningOp();
     if (ptrDefiningOp->hasAttr(WRAP_SIDE_BY_SIDE) ||
-        ptrDefiningOp->hasAttr(WRAP_STACKED)) {
+        ptrDefiningOp->hasAttr(WRAP_STACKED) ||
+        ptrDefiningOp->hasAttr(WRAP_1D)) {
 
       auto unrealizedCast = cast<UnrealizedConversionCastOp>(ptrDefiningOp);
 
@@ -782,6 +943,10 @@ private:
         auto [subview1, subview2] =
             getStackedSubviews(mixedDims, block1, block2, loc, rewriter);
         createStackedCopies(subview1, subview2, alloc, loc, rewriter);
+      } else if (unrealizedCast->hasAttr(WRAP_1D)) {
+        auto [subview1, subview2] =
+            get1DSubviews(mixedDims, block1, block2, loc, rewriter);
+        create1DCopies(subview1, subview2, alloc, loc, rewriter);
       } else {
         llvm_unreachable("unexpected wraparound type");
       }
@@ -1122,6 +1287,75 @@ public:
     auto ptr = adaptor.getPtr();
     auto storeValue = op.getValue();
     auto rank = cast<RankedTensorType>(storeValue.getType()).getRank();
+
+    // Handle 1D circular-buffer wrap-around store: store into two contiguous
+    // segments that together span the block.
+    auto ptrDefiningOp = ptr.getDefiningOp();
+    if (ptrDefiningOp && ptrDefiningOp->hasAttr(WRAP_1D)) {
+      auto unrealizedCast = cast<UnrealizedConversionCastOp>(ptrDefiningOp);
+      auto memrefs = unrealizedCast.getOperands();
+      assert(memrefs.size() == 2);
+      Value block1 = memrefs[0];
+      Value block2 = memrefs[1];
+
+      Value d1 = memref::DimOp::create(rewriter, loc, block1, 0);
+      Value d2 = memref::DimOp::create(rewriter, loc, block2, 0);
+      Value zero =
+          arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
+      Value one =
+          arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
+
+      if (op.hasMask()) {
+        auto mixedDims = op.getMixedMaskDims();
+        // Clip store slices to the mask size (dims[0] for the 1D case).
+        // Use d1/d2 directly from the cast ops since they are already sized.
+        auto slice1 = tensor::ExtractSliceOp::create(
+            rewriter, loc, storeValue,
+            SmallVector<OpFoldResult>{rewriter.getIndexAttr(0)},
+            SmallVector<OpFoldResult>{OpFoldResult(d1)},
+            SmallVector<OpFoldResult>{rewriter.getIndexAttr(1)});
+        auto dst1Subview = memref::SubViewOp::create(
+            rewriter, loc, block1, ValueRange{zero}, ValueRange{d1},
+            ValueRange{one});
+        auto store1 = bufferization::MaterializeInDestinationOp::create(
+            rewriter, loc, slice1, dst1Subview);
+        store1.setWritable(true);
+
+        auto slice2 = tensor::ExtractSliceOp::create(
+            rewriter, loc, storeValue,
+            SmallVector<OpFoldResult>{OpFoldResult(d1)},
+            SmallVector<OpFoldResult>{OpFoldResult(d2)},
+            SmallVector<OpFoldResult>{rewriter.getIndexAttr(1)});
+        auto dst2Subview = memref::SubViewOp::create(
+            rewriter, loc, block2, ValueRange{zero}, ValueRange{d2},
+            ValueRange{one});
+        auto store2 = bufferization::MaterializeInDestinationOp::create(
+            rewriter, loc, slice2, dst2Subview);
+        store2.setWritable(true);
+      } else {
+        // Unmasked: store first d1 elements to chunk1, next d2 to chunk2.
+        auto slice1 = tensor::ExtractSliceOp::create(
+            rewriter, loc, storeValue,
+            SmallVector<OpFoldResult>{rewriter.getIndexAttr(0)},
+            SmallVector<OpFoldResult>{OpFoldResult(d1)},
+            SmallVector<OpFoldResult>{rewriter.getIndexAttr(1)});
+        auto store1 = bufferization::MaterializeInDestinationOp::create(
+            rewriter, loc, slice1, block1);
+        store1.setWritable(true);
+
+        auto slice2 = tensor::ExtractSliceOp::create(
+            rewriter, loc, storeValue,
+            SmallVector<OpFoldResult>{OpFoldResult(d1)},
+            SmallVector<OpFoldResult>{OpFoldResult(d2)},
+            SmallVector<OpFoldResult>{rewriter.getIndexAttr(1)});
+        auto store2 = bufferization::MaterializeInDestinationOp::create(
+            rewriter, loc, slice2, block2);
+        store2.setWritable(true);
+      }
+
+      rewriter.eraseOp(op);
+      return success();
+    }
 
     if (op.hasMask()) {
       auto mixedDims = op.getMixedMaskDims();

--- a/python/examples/test_modulo.py
+++ b/python/examples/test_modulo.py
@@ -387,3 +387,34 @@ def test_torch_inductor_pattern():
         dtype=torch.int32)
 
     assert torch.equal(expected_out.int(), out.int())
+
+
+def test_wrap_1d(device):
+
+    @triton.jit
+    def wrap_1d_mul(weight_ptr, in_ptr, out_ptr, xnumel, N,
+                    XBLOCK: tl.constexpr):
+        xoffset = tl.program_id(0) * XBLOCK
+        xindex = xoffset + tl.arange(0, XBLOCK)[:]
+        xmask = xindex < xnumel
+        x0 = xindex % N
+        w = tl.load(weight_ptr + x0, xmask)
+        x = tl.load(in_ptr + xindex, xmask)
+        tl.store(out_ptr + xindex, w * x, xmask)
+
+    N = 8
+    xnumel = N * 4  # 32 — two full tiles each crossing the N boundary
+    XBLOCK = 16
+
+    weight = torch.arange(0, N, device=device, dtype=torch.float32)
+    inp = torch.ones(xnumel, device=device, dtype=torch.float32)
+    out = torch.zeros(xnumel, device=device, dtype=torch.float32)
+
+    grid = lambda meta: (triton.cdiv(xnumel, meta['XBLOCK']),)
+    wrap_1d_mul[grid](weight, inp, out, xnumel, N, XBLOCK=XBLOCK)
+
+    # out[i] = weight[i % N] * 1.0 = float(i % N)
+    expected = torch.tensor([float(i % N) for i in range(xnumel)],
+                            device=device,
+                            dtype=torch.float32)
+    assert torch.equal(out, expected)

--- a/test/Conversion/StructuredToMemref/wraparound_1d.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_1d.mlir
@@ -1,0 +1,178 @@
+// RUN: triton-shared-opt --split-input-file --structured-to-memref %s | FileCheck %s
+
+// Tests for the 1D circular-buffer split-pointer path (WRAP_1D).
+//
+// Pattern: ptr[i % N] — a 1D tts.make_tptr whose shape[0] is non-zero (set
+// by PtrAnalysis::visitOperandRem) causes isSplitPtr()==true with
+// parentShape.size()==1.  Before this fix that hit:
+//   assert(parentShape.size() == 2 && "Only support split pointer for 2D tensors only")
+//
+// The fix (create1DCastOps) produces two contiguous memref chunks. The split
+// SIZE math is done in element units (dividing by the stride, via the shared
+// computeWrapSizes helper), so it also handles the non-unit-stride pattern
+// ptr[stride * (i % N)] correctly:
+//   xAddr   = startOffset % N          (start position, ADDRESS units)
+//   xElem   = xAddr / stride           (start position, ELEMENT units)
+//   elemN   = N / stride               (modulo period, in elements)
+//   d1      = min(xElem + XBLOCK, elemN) - xElem  (elements before boundary)
+//   d2      = XBLOCK - d1                          (elements after wrap, may 0)
+// The 1D chunk offsets (unlike the 2D side-by-side case) are:
+//   chunk1: reinterpret_cast base[xAddr], size=d1, stride=stride
+//           (xAddr = startOffset % N correctly wraps a tile that starts a
+//            whole period past the buffer, where raw startOffset would be OOB)
+//   chunk2: reinterpret_cast base[0],     size=d2, stride=stride
+//           (the period always restarts at flat address 0 in 1D)
+// create1DCopies then assembles: dst[0..d1) <- chunk1, dst[d1..XBLOCK) <- chunk2.
+
+// -----
+
+// Unmasked 1D circular-buffer load.
+// startOffset = 4 (static), XBLOCK = 8, modulo = %N (dynamic).
+
+// CHECK-LABEL: tt.func public @wrap_1d_unmasked_load
+module {
+  tt.func public @wrap_1d_unmasked_load(%arg0: !tt.ptr<f32>, %N: index) -> tensor<8xf32> {
+    %c4 = arith.constant 4 : index
+    %ptr = tts.make_tptr %arg0 to sizes: [8], strides: [1], offsets: [%c4], shape: [%N], order: [] : <f32> to tensor<8x!tt.ptr<f32>>
+    %result = "tts.load"(%ptr) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<8x!tt.ptr<f32>>) -> tensor<8xf32>
+    tt.return %result : tensor<8xf32>
+  }
+}
+
+// CHECK:     [[BASE:%.+]] = builtin.unrealized_conversion_cast {{%.+}} : !tt.ptr<f32> to memref<*xf32>
+// CHECK-DAG: [[C4:%.+]] = arith.constant 4 : index
+// CHECK-DAG: [[C8:%.+]] = arith.constant 8 : index
+// CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
+// CHECK:     [[XADDR:%.+]] = arith.remsi [[C4]], {{%.+}} : index
+// CHECK:     [[XELEM:%.+]] = arith.divsi [[XADDR]], [[C1]] : index
+// CHECK:     [[ELEMN:%.+]] = arith.divsi {{%.+}}, [[C1]] : index
+// CHECK:     [[NEXT:%.+]] = arith.addi [[XELEM]], [[C8]] : index
+// CHECK:     [[CLAMPED:%.+]] = arith.minsi [[NEXT]], [[ELEMN]] : index
+// CHECK:     [[D1:%.+]] = arith.subi [[CLAMPED]], [[XELEM]] : index
+// CHECK:     [[D2:%.+]] = arith.subi [[C8]], [[D1]] : index
+// CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
+// CHECK:     [[CAST1:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[XADDR]]], sizes: {{\[}}[[D1]]], strides: {{\[}}[[C1]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[CAST2:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[C0]]], sizes: {{\[}}[[D2]]], strides: {{\[}}[[C1]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     {{%.+}} = builtin.unrealized_conversion_cast [[CAST1]], [[CAST2]] {{.*}} {wrap_1d}
+// CHECK:     [[ALLOC:%.+]] = memref.alloc() : memref<8xf32>
+// CHECK:     [[DIM1:%.+]] = memref.dim [[CAST1]], {{%.+}} : memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[DIM2:%.+]] = memref.dim [[CAST2]], {{%.+}} : memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[DST1:%.+]] = memref.subview [[ALLOC]]{{.*}} : memref<8xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[DST2:%.+]] = memref.subview [[ALLOC]]{{.*}} : memref<8xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     memref.copy [[CAST1]], [[DST1]]
+// CHECK:     memref.copy [[CAST2]], [[DST2]]
+// CHECK:     {{%.+}} = bufferization.to_tensor [[ALLOC]] restrict writable : memref<8xf32>
+
+// -----
+
+// Masked 1D circular-buffer load with static mask dim (6) and scalar other (0.0).
+// The unrealized_conversion_cast is erased by rewriteMaskedLoad; the cast ops
+// are referenced directly.
+
+// CHECK-LABEL: tt.func public @wrap_1d_masked_load
+module {
+  tt.func public @wrap_1d_masked_load(%arg0: !tt.ptr<f32>, %N: index) -> tensor<8xf32> {
+    %c4 = arith.constant 4 : index
+    %cst = arith.constant 0.0 : f32
+    %ptr = tts.make_tptr %arg0 to sizes: [8], strides: [1], offsets: [%c4], shape: [%N], order: [] : <f32> to tensor<8x!tt.ptr<f32>>
+    %result = "tts.load"(%ptr, %cst) <{operandSegmentSizes = array<i32: 1, 0, 1>, static_mask_dims = array<i64: 6>}> : (tensor<8x!tt.ptr<f32>>, f32) -> tensor<8xf32>
+    tt.return %result : tensor<8xf32>
+  }
+}
+
+// CHECK:     [[BASE:%.+]] = builtin.unrealized_conversion_cast {{%.+}} : !tt.ptr<f32> to memref<*xf32>
+// CHECK:     [[C4:%.+]] = arith.constant 4 : index
+// CHECK:     [[CST:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: [[C8:%.+]] = arith.constant 8 : index
+// CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
+// CHECK:     [[XADDR:%.+]] = arith.remsi [[C4]], {{%.+}} : index
+// CHECK:     [[XELEM:%.+]] = arith.divsi [[XADDR]], [[C1]] : index
+// CHECK:     [[ELEMN:%.+]] = arith.divsi {{%.+}}, [[C1]] : index
+// CHECK:     [[NEXT:%.+]] = arith.addi [[XELEM]], [[C8]] : index
+// CHECK:     [[CLAMPED:%.+]] = arith.minsi [[NEXT]], [[ELEMN]] : index
+// CHECK:     [[D1:%.+]] = arith.subi [[CLAMPED]], [[XELEM]] : index
+// CHECK:     [[D2:%.+]] = arith.subi [[C8]], [[D1]] : index
+// CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
+// CHECK:     [[CAST1:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[XADDR]]], sizes: {{\[}}[[D1]]], strides: {{\[}}[[C1]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[CAST2:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[C0]]], sizes: {{\[}}[[D2]]], strides: {{\[}}[[C1]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[ALLOC:%.+]] = memref.alloc() : memref<8xf32>
+// CHECK:     scf.if
+// CHECK:       linalg.fill ins([[CST]] : f32) outs([[ALLOC]] : memref<8xf32>)
+// CHECK:     memref.copy
+// CHECK:     memref.copy
+// CHECK:     {{%.+}} = bufferization.to_tensor [[ALLOC]] restrict writable : memref<8xf32>
+
+// -----
+
+// 1D circular-buffer store.
+
+// CHECK-LABEL: tt.func public @wrap_1d_store
+module {
+  tt.func public @wrap_1d_store(%arg0: !tt.ptr<f32>, %N: index, %val: tensor<8xf32>) {
+    %c4 = arith.constant 4 : index
+    %ptr = tts.make_tptr %arg0 to sizes: [8], strides: [1], offsets: [%c4], shape: [%N], order: [] : <f32> to tensor<8x!tt.ptr<f32>>
+    "tts.store"(%ptr, %val) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_mask_dims = array<i64>}> : (tensor<8x!tt.ptr<f32>>, tensor<8xf32>) -> ()
+    tt.return
+  }
+}
+
+// CHECK:     [[BASE:%.+]] = builtin.unrealized_conversion_cast {{%.+}} : !tt.ptr<f32> to memref<*xf32>
+// CHECK-DAG: [[C4:%.+]] = arith.constant 4 : index
+// CHECK-DAG: [[C8:%.+]] = arith.constant 8 : index
+// CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
+// CHECK:     [[XADDR:%.+]] = arith.remsi [[C4]], {{%.+}} : index
+// CHECK:     [[XELEM:%.+]] = arith.divsi [[XADDR]], [[C1]] : index
+// CHECK:     [[ELEMN:%.+]] = arith.divsi {{%.+}}, [[C1]] : index
+// CHECK:     [[NEXT:%.+]] = arith.addi [[XELEM]], [[C8]] : index
+// CHECK:     [[CLAMPED:%.+]] = arith.minsi [[NEXT]], [[ELEMN]] : index
+// CHECK:     [[D1:%.+]] = arith.subi [[CLAMPED]], [[XELEM]] : index
+// CHECK:     [[D2:%.+]] = arith.subi [[C8]], [[D1]] : index
+// CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
+// CHECK:     [[CAST1:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[XADDR]]], sizes: {{\[}}[[D1]]], strides: {{\[}}[[C1]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[CAST2:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[C0]]], sizes: {{\[}}[[D2]]], strides: {{\[}}[[C1]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     {{%.+}} = builtin.unrealized_conversion_cast [[CAST1]], [[CAST2]] {{.*}} {wrap_1d}
+// CHECK:     [[DIM1:%.+]] = memref.dim [[CAST1]], {{%.+}} : memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[DIM2:%.+]] = memref.dim [[CAST2]], {{%.+}} : memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[SLICE1:%.+]] = tensor.extract_slice {{%.+}}[0] {{\[}}[[DIM1]]] [1]
+// CHECK:     bufferization.materialize_in_destination [[SLICE1]] in writable [[CAST1]]
+// CHECK:     [[SLICE2:%.+]] = tensor.extract_slice {{%.+}}{{\[}}[[DIM1]]] {{\[}}[[DIM2]]] [1]
+// CHECK:     bufferization.materialize_in_destination [[SLICE2]] in writable [[CAST2]]
+
+// -----
+
+// Non-unit-stride 1D circular-buffer load: ptr[stride * (i % N)] with a
+// constant stride of 3 (modulo period 96 in address units == 32 in elements).
+// This is the pattern that reaches this path from a tiled rotary-embedding
+// kernel (`cat(freqs, freqs)` lowered to `3*(x % 32)`). Before the stride-aware
+// fix, create1DCastOps hardcoded stride 1 and compared the element block size
+// directly against the address-unit modulo bound, collapsing the whole access
+// to a plain contiguous stride-1 copy. The reinterpret_casts below must carry
+// the real stride of 3, and the split SIZE math must divide by it (arith.divsi
+// by the constant 3).
+
+// CHECK-LABEL: tt.func public @wrap_1d_stride3_load
+module {
+  tt.func public @wrap_1d_stride3_load(%arg0: !tt.ptr<f32>) -> tensor<8xf32> {
+    %c96 = arith.constant 96 : index
+    %c0 = arith.constant 0 : index
+    %ptr = tts.make_tptr %arg0 to sizes: [8], strides: [3], offsets: [%c0], shape: [%c96], order: [] : <f32> to tensor<8x!tt.ptr<f32>>
+    %result = "tts.load"(%ptr) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<8x!tt.ptr<f32>>) -> tensor<8xf32>
+    tt.return %result : tensor<8xf32>
+  }
+}
+
+// CHECK:     [[BASE:%.+]] = builtin.unrealized_conversion_cast {{%.+}} : !tt.ptr<f32> to memref<*xf32>
+// CHECK-DAG: [[C96:%.+]] = arith.constant 96 : index
+// CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
+// CHECK-DAG: [[C8:%.+]] = arith.constant 8 : index
+// CHECK-DAG: [[C3:%.+]] = arith.constant 3 : index
+// CHECK:     [[XADDR:%.+]] = arith.remsi [[C0]], [[C96]] : index
+// CHECK:     [[XELEM:%.+]] = arith.divsi [[XADDR]], [[C3]] : index
+// CHECK:     [[ELEMN:%.+]] = arith.divsi [[C96]], [[C3]] : index
+// CHECK:     [[NEXT:%.+]] = arith.addi [[XELEM]], [[C8]] : index
+// CHECK:     [[CLAMPED:%.+]] = arith.minsi [[NEXT]], [[ELEMN]] : index
+// CHECK:     [[D1:%.+]] = arith.subi [[CLAMPED]], [[XELEM]] : index
+// CHECK:     [[D2:%.+]] = arith.subi [[C8]], [[D1]] : index
+// CHECK-DAG: [[C0_2:%.+]] = arith.constant 0 : index
+// CHECK:     [[CAST1:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[XADDR]]], sizes: {{\[}}[[D1]]], strides: {{\[}}[[C3]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:     [[CAST2:%.+]] = memref.reinterpret_cast [[BASE]] to offset: {{\[}}[[C0_2]]], sizes: {{\[}}[[D2]]], strides: {{\[}}[[C3]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>

--- a/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
@@ -87,14 +87,16 @@ module {
 // CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg16_]]{{.}}, sizes: [4, 4], strides: {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<*xf32> to memref<4x4xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_4_]] : index
 // CHECK:             [[VAR_14_:%.+]] = arith.remsi [[VAR_13_]], [[VAR_5_]] : index
-// CHECK-DAG:         [[VAR_15_:%.+]] = arith.subi [[VAR_13_]], [[VAR_14_]] : index
-// CHECK-DAG:         [[VAR_16_:%.+]] = arith.addi [[VAR_14_]], [[CST_4_]] : index
-// CHECK:             [[VAR_17_:%.+]] = arith.minsi [[VAR_16_]], [[VAR_5_]] : index
-// CHECK:             [[VAR_18_:%.+]] = arith.subi [[VAR_17_]], [[VAR_14_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: [4, [[VAR_18_]]], strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
-// CHECK-DAG:         [[VAR_19_:%.+]] = arith.subi [[CST_4_]], [[VAR_18_]] : index
+// CHECK-DAG:         [[VAR_15_:%.+]] = arith.divsi [[VAR_14_]], [[VAR_3_]] : index
+// CHECK-DAG:         [[VAR_16_:%.+]] = arith.divsi [[VAR_5_]], [[VAR_3_]] : index
+// CHECK-DAG:         [[VAR_17_:%.+]] = arith.addi [[VAR_15_]], [[CST_4_]] : index
+// CHECK:             [[VAR_18_:%.+]] = arith.minsi [[VAR_17_]], [[VAR_16_]] : index
+// CHECK:             [[VAR_19_:%.+]] = arith.subi [[VAR_18_]], [[VAR_15_]] : index
+// CHECK-DAG:         [[VAR_20_:%.+]] = arith.subi [[CST_4_]], [[VAR_19_]] : index
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.subi [[VAR_13_]], [[VAR_14_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: [4, [[VAR_19_]]], strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: [4, [[VAR_19_]]], strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_21_]]{{.}}, sizes: [4, [[VAR_20_]]], strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
 // CHECK:             linalg.fill ins([[CST_minus_9_dot_900000_]] : f32) outs([[RES_]] : memref<4x4xf32>)
 // CHECK:             [[DIM_0:%.+]] = memref.dim [[VAR_reinterpret_cast_0_]], [[CONSTANT_0]] : memref<4x?xf32, strided<[?, ?], offset: ?>>
@@ -106,11 +108,11 @@ module {
 // CHECK-DAG:         [[VAR_subview_4_:%.+]] = memref.subview [[RES_]][0, [[DIM_0]]{{.}} [2, [[DIM_1]]{{.}} [1, 1] : memref<4x4xf32> to memref<2x?xf32, strided<[4, 1], offset: ?>>
 // CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_3_]] : memref<2x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[4, 1]>>
 // CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_4_]] : memref<2x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[4, 1], offset: ?>>
-// CHECK:             [[VAR_20_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
-// CHECK:             bufferization.materialize_in_destination [[VAR_20_]] in writable [[VAR_reinterpret_cast_]] : (tensor<4x4xf32>, memref<4x4xf32, strided<[?, ?], offset: ?>>) -> ()
-// CHECK-DAG:         [[VAR_21_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_9_]] : index
-// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_arg16_]], [[VAR_11_]] : index
-// CHECK:             scf.yield [[VAR_21_]], [[VAR_22_]] : index, index
+// CHECK:             [[VAR_22_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
+// CHECK:             bufferization.materialize_in_destination [[VAR_22_]] in writable [[VAR_reinterpret_cast_]] : (tensor<4x4xf32>, memref<4x4xf32, strided<[?, ?], offset: ?>>) -> ()
+// CHECK-DAG:         [[VAR_23_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_9_]] : index
+// CHECK-DAG:         [[VAR_24_:%.+]] = arith.addi [[VAR_arg16_]], [[VAR_11_]] : index
+// CHECK:             scf.yield [[VAR_23_]], [[VAR_24_]] : index, index
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
Extend rewriteSplitPtr to handle rank-1 split pointers produced by PtrAnalysis::visitOperandRem. Previously the assert required rank == 2.

The failing kernel was triton_poi_fused_mul_4, the RMSNorm weight-broadcast multiply (weight[i % 2048] * input[i]), when compiled via torch.compile/inductor with --enable-triton:

```
  @triton_heuristics.pointwise(
      size_hints={'x': 65536},
      filename=__file__,
      triton_meta={'signature': {'in_out_ptr0': '*fp32', 'in_ptr0': '*fp32',
                                 'xnumel': 'i32', 'XBLOCK': 'constexpr'},
                   'device': DeviceProperties(type='qaic', index=0,
                       multi_processor_count=16, cc=None, major=None,
                       regs_per_multiprocessor=None,
                       max_threads_per_multi_processor=None,
                       max_threads_per_block=1024, warp_size=32),
                   'constants': {}, 'native_matmul': False,
                   'configs': [{(0,): [['tt.divisibility', 16]],
                                (2,): [['tt.divisibility', 16]]}],
                   'enable_fp_fusion': True},
      inductor_meta={'grid_type': 'Grid1D', 'autotune_hints': set(),
                     'kernel_name': 'triton_poi_fused_mul_4',
                     'mutated_arg_names': ['in_out_ptr0'],
                     'optimize_mem': True, 'no_x_dim': False, ...},
      min_elem_per_thread=0
  )
  @triton.jit
  def triton_poi_fused_mul_4(in_out_ptr0, in_ptr0, xnumel, XBLOCK : tl.constexpr):
      xoffset = tl.program_id(0) * XBLOCK
      xindex = xoffset + tl.arange(0, XBLOCK)[:]
      xmask = xindex < xnumel
      x0 = (xindex % 2048)
      x2 = xindex
      tmp0 = tl.load(in_ptr0 + (x0), xmask, eviction_policy='evict_last')
      tmp1 = tl.load(in_out_ptr0 + (x2), xmask)
      tmp2 = tmp0 * tmp1
      tl.store(in_out_ptr0 + (x2), tmp2, xmask)
```

The load of in_ptr0 + (x0) — where x0 = xindex % 2048 — is a purely 1D circular-buffer access. PtrAnalysis::visitOperandRem sets state.shape[0] = N (here 2048), making isSplitPtr() return true with parentShape.size() == 1. rewriteSplitPtr previously asserted rank == 2, causing the SIGABRT.

Add create1DCastOps (two ReinterpretCastOps for the two contiguous circular-buffer segments), create1DCopies, get1DSubviews, and a WRAP_1D store path to StoreConverter. Add wraparound_1d.mlir FileCheck test.