### PR TITLE
Add option to disable modulo pointer analysis

### DIFF
--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -149,6 +149,7 @@ class PtrAnalysis {
 
   DenseSet<Value> maybeStructuredArgs;
   const bool enableMakeGatherScatterTensorPtr;
+  const bool enableModuloSupport;
   // If false, PtrAnalysis will analysis structured ptr while only identify
   // unstructured ptr.
   // If true, PtrAnalysis will caclulate strides and offsets for
@@ -186,8 +187,10 @@ class PtrAnalysis {
   bool isAnalysisingUnstructured = false;
 
 public:
-  PtrAnalysis(bool enableMakeGatherScatterTensorPtr)
-      : enableMakeGatherScatterTensorPtr(enableMakeGatherScatterTensorPtr) {}
+  PtrAnalysis(bool enableMakeGatherScatterTensorPtr,
+              bool enableModuloSupport = true)
+      : enableMakeGatherScatterTensorPtr(enableMakeGatherScatterTensorPtr),
+        enableModuloSupport(enableModuloSupport) {}
   void initializeMaybeStructuredArgs(Operation *op);
 
   llvm::SmallDenseMap<Value, PtrState> knownPtrs;

--- a/include/triton-shared/Conversion/TritonToStructured/Passes.td
+++ b/include/triton-shared/Conversion/TritonToStructured/Passes.td
@@ -16,6 +16,8 @@ def TritonToStructured : Pass<"triton-to-structured", "mlir::ModuleOp"> {
   let options = [
       Option<"enableMakeGatherScatterTensorPtr", "enable-make-gather-scatter", "bool", /*default*/"true",
              "Enable make_gather_scatter_tptr support">,
+      Option<"enableModuloSupport", "enable-modulo-support", "bool", /*default*/"true",
+             "Enable modulo operation support in pointer analysis">,
       Option<"runPrepassOnly", "run-prepass-only", "bool", /*default*/"false",
              "Only run the pre-processing pass which inserts tts.get_structured_state ops used in scf.for">,
       Option<"skipPrepass", "skip-prepass", "bool", /*default*/"false",

--- a/include/triton-shared/Conversion/TritonToStructured/TritonToStructured.h
+++ b/include/triton-shared/Conversion/TritonToStructured/TritonToStructured.h
@@ -20,7 +20,8 @@ namespace triton {
 #include "triton-shared/Conversion/TritonToStructured/Passes.h.inc"
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createTritonToStructuredPass(bool enableMakeGatherScatterTensorPtr = true);
+createTritonToStructuredPass(bool enableMakeGatherScatterTensorPtr = true,
+                             bool enableModuloSupport = true);
 
 } // namespace triton
 } // namespace mlir

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -799,6 +799,11 @@ LogicalResult PtrAnalysis::visitOperandRem(arith::RemSIOp remOp,
                                            PtrState &state, const Location loc,
                                            OpBuilder &builder) {
   assert(state.isEmpty());
+
+  if (!enableModuloSupport) {
+    return failure();
+  }
+
   if (isAnalysisingUnstructured) {
     assert(enableMakeGatherScatterTensorPtr &&
            "PtrAnalysis: isAnalysisingUnstructured should only be true "

--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -321,7 +321,8 @@ public:
     }
 
     auto moduleOp = getOperation();
-    mlir::tts::PtrAnalysis ptrAnalysis(enableMakeGatherScatterTensorPtr);
+    mlir::tts::PtrAnalysis ptrAnalysis(enableMakeGatherScatterTensorPtr,
+                                       enableModuloSupport);
     ptrAnalysis.initializeMaybeStructuredArgs(moduleOp);
 
     if (failed(ptrAnalysis.rewriteOp(moduleOp, useUnsafeMask))) {
@@ -340,8 +341,10 @@ public:
 } // namespace
 
 std::unique_ptr<OperationPass<ModuleOp>>
-triton::createTritonToStructuredPass(bool enableMakeGatherScatterTensorPtr) {
+triton::createTritonToStructuredPass(bool enableMakeGatherScatterTensorPtr,
+                                     bool enableModuloSupport) {
   TritonToStructuredOptions options;
   options.enableMakeGatherScatterTensorPtr = enableMakeGatherScatterTensorPtr;
+  options.enableModuloSupport = enableModuloSupport;
   return std::make_unique<TritonToStructuredPass>(options);
 }

--- a/test/Conversion/TritonToStructured/modulo_option.mlir
+++ b/test/Conversion/TritonToStructured/modulo_option.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-shared-opt --triton-to-structured="enable-modulo-support=false" --canonicalize %s | FileCheck %s --check-prefix=CHECK-DISABLED
+// RUN: triton-shared-opt --triton-to-structured="enable-modulo-support=true" --canonicalize %s | FileCheck %s --check-prefix=CHECK-ENABLED
+module {
+  tt.func public @modulo(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32) attributes {noinline = false} {
+    %c16_i32 = arith.constant 16 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c16_i32 : i32
+    %2 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %3 = tt.splat %1 : i32 -> tensor<16xi32>
+    %4 = arith.addi %3, %2 : tensor<16xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<16xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<16xi32>
+    %7 = tt.splat %arg3 : i32 -> tensor<16xi32>
+    %8 = arith.remsi %4, %7 : tensor<16xi32>
+    %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %10 = tt.addptr %9, %8 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    %11 = tt.load %10, %6 : tensor<16x!tt.ptr<f32>>
+    %12 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
+    %13 = tt.addptr %12, %4 : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
+    tt.store %13, %11, %6 : tensor<16x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// Check when modulo is disabled, we should not generate a tts.load
+// CHECK-DISABLED-LABEL: @modulo
+// CHECK-DISABLED-NOT: tts.load
+// CHECK-DISABLED: tt.load
+// CHECK-DISABLED-NOT: tt.store
+// CHECK-DISABLED: tts.store
+
+
+// Check when modulo is enabled, we should generate a tts.load
+// CHECK-ENABLED-LABEL: @modulo(
+// CHECK-ENABLED-SAME: %{{.+}}: !tt.ptr<f32>, %{{.+}}: !tt.ptr<f32>, %{{.+}}: i32, [[MODARG:%[a-zA-Z0-9_]+]]: i32, %{{.+}}: i32)
+// CHECK-ENABLED-NOT: tt.load
+// CHECK-ENABLED-NOT: tt.store
+// CHECK-ENABLED: [[SHAPE:%.+]] = arith.index_cast [[MODARG]] : i32 to index
+// CHECK-ENABLED: [[PTR:%.+]] = tts.make_tptr %{{.+}} to sizes: [16], strides: [1], offsets: [{{%.+}}], shape: {{\[}}[[SHAPE]]{{\]}}, order: []
+// CHECK-ENABLED: "tts.load"([[PTR]], {{.+}})
+// CHECK-ENABLED: tts.store


### PR DESCRIPTION
Summary:
- Add an enable-modulo-support option to triton-to-structured pointer analysis.
- Preserve current behavior by default, while allowing modulo pointer handling to be disabled.
- Add a lit regression covering both enabled and disabled modes.